### PR TITLE
use base64 image for image acceptance test

### DIFF
--- a/src/lib/compliance-tests.ts
+++ b/src/lib/compliance-tests.ts
@@ -182,7 +182,8 @@ export const testTemplates: TestTemplate[] = [
             {
               type: "input_image",
               image_url:
-                "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+                // a red heart icon on a white background
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAABmklEQVR42tyWAaTyUBzFew/eG4AHz+MBSAHKBiJRGFKwIgQQJKLUIioBIhCAiCAAEizAQIAECaASqFFJq84nudjnaqvuPnxzgP9xfrq5938csPn7PwHTKSoViCIEAYEAMhmoKsU2mUCWEQqB5xEMIp/HaGQG2G6RSuH9HQ7H34rFrtPbdz4jl6PbwmEsl3QA1mt4vcRKk8dz9eg6IpF7tt9fzGY0gCgafFRFo5Blc5vLhf3eCOj1yNhM5GRMVK0aATxPZoz09YXjkQDmczJgquGQAPp9WwCNBgG027YACgUC6HRsAZRKBDAY2AJoNv/ZnwzA6WScznG3p4UAymXGAEkyXrTFAh8fLAGqagQAyGaZpYsi7bHTNPz8MEj//LxuFPo+UBS8vb0KaLXubrRa7aX0RMLCykwmn0z3+XA4WACcTpCkh9MFAZpmuVXo+mO/w+/HZvNgbblcUCxaSo/Hyck80Yu6XXDcvfVZr79cvMZjuN2U9O9vKAqjZrfbIZ0mV4TUi9Xqz6jddNy//7+e3n8Fhf/Llo2kxi8AQyGRoDkmAhAAAAAASUVORK5CYII=",
             },
           ],
         },


### PR DESCRIPTION
This is a broader test than requiring providers to fetch remote images.

Not all providers necessarily will support fetching remote images. I replaced the existing test since the current test suite seems aimed more at broad support, but I imagine a remote fetching test being added back as more fine-grained tests are added in the future.