### PR TITLE
add @typespec/prettier-plugin-typespec dev dep

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "@kubb/core": "^4.15.0",
         "@kubb/plugin-oas": "^4.15.0",
         "@kubb/plugin-zod": "^4.15.0",
+        "@typespec/prettier-plugin-typespec": "^1.8.0",
         "autoprefixer": "^10.4.21",
         "concurrently": "^9.1.0",
         "husky": "^9.1.7",
@@ -511,6 +512,8 @@
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@typespec/prettier-plugin-typespec": ["@typespec/prettier-plugin-typespec@1.8.0", "", { "dependencies": { "prettier": "~3.7.4" } }, "sha512-PGAWhnnX2CIQPS5irQEAidzog9IZigM4fXFIuiBLwAIh1ZXd31fluzRSU0gthvnkxVtNPOWSn8SR7R8ca/Z7yQ=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@kubb/core": "^4.15.0",
     "@kubb/plugin-oas": "^4.15.0",
     "@kubb/plugin-zod": "^4.15.0",
+    "@typespec/prettier-plugin-typespec": "^1.8.0",
     "autoprefixer": "^10.4.21",
     "concurrently": "^9.1.0",
     "husky": "^9.1.7",


### PR DESCRIPTION
Previously I was having trouble with the git pre-commit hook, which was giving me the error

```
✖ prettier --write --ignore-unknown:
[error] Cannot find module '<repo_path>/node_modules/@typespec/prettier-plugin-typespec/dist/index.js' imported from $HOME/.bun/install/global/node_modules/prettier/index.mjs
husky - pre-commit script failed (code 1)
```

This plugin is referenced in `prettier.config.js`, so I added it as a dev dep