### PR TITLE
Fix typos in specification.mdx

### DIFF
--- a/src/pages/specification.mdx
+++ b/src/pages/specification.mdx
@@ -141,7 +141,7 @@ In Open Responses, all items have a lifecycle. They can be `in_progress` if the 
 
 It's important to note that while items follow a state machine model—transitioning through these defined states—this does not necessarily mean they are stateful in the sense of being persisted to disk or stored long-term. The state machine describes the item's status within the response flow, but persistence is a separate concern and is not implied by the item's state transitions.
 
-All item types should have these three basic states:
+All item types should have these three basic statuses:
 
 - `in_progress` - the model is currently emitting tokens belonging to this item
 - `incomplete` - the model has exhausted its token budget while emitting tokens belonging to this item. This is a terminal state. If an item ends in a terminal state, it MUST be the last item emitted, and the containing response also MUST be in an `incomplete` state.


### PR DESCRIPTION
Fix typos in spec doc.

For `status → states`: needed plural, and "states" felt more natural than "statuses" here.