### PR TITLE
Include all required fields in ResponseResource example.

### DIFF
--- a/public/openapi/openapi.json
+++ b/public/openapi/openapi.json
@@ -2602,7 +2602,9 @@
             },
             "total_tokens": 380
           },
-          "metadata": {}
+          "metadata": {},
+          "service_tier": "default",
+          "top_logprobs": 0
         }
       },
       "ResponseCreatedStreamingEvent": {

--- a/schema/components/schemas/ResponseResource.json
+++ b/schema/components/schemas/ResponseResource.json
@@ -411,7 +411,9 @@
       },
       "total_tokens": 380
     },
-    "metadata": {}
+    "metadata": {},
+    "service_tier": "default",
+    "top_logprobs": 0
   },
   "x-openai-class-name": "responsesapi.api.resources.response_resource.ResponseBody"
 }


### PR DESCRIPTION
The example provided for ResponseResource is missing the service_tier and top_logprobs fields which are marked as required in the schema. Add these fields to the example so they are valid.

I regenerated the public spec but the formatting changed significantly as enums were being split across multiple lines.  I've therefore just included the appropriate bits in the public spec to make the change reviewable.