### PR TITLE
Change streaming type discriminator from 'reasoning' to 'reasoning_text'

### DIFF
--- a/public/openapi/openapi.json
+++ b/public/openapi/openapi.json
@@ -3317,9 +3317,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.reasoning.delta"],
-            "description": "The type of the event, always `response.reasoning.delta`.",
-            "default": "response.reasoning.delta"
+            "enum": ["response.reasoning_text.delta"],
+            "description": "The type of the event, always `response.reasoning_text.delta`.",
+            "default": "response.reasoning_text.delta"
           },
           "sequence_number": {
             "type": "integer",
@@ -3362,9 +3362,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.reasoning.done"],
-            "description": "The type of the event, always `response.reasoning.done`.",
-            "default": "response.reasoning.done"
+            "enum": ["response.reasoning_text.done"],
+            "description": "The type of the event, always `response.reasoning_text.done`.",
+            "default": "response.reasoning_text.done"
           },
           "sequence_number": {
             "type": "integer",

--- a/schema/components/schemas/ResponseReasoningDeltaStreamingEvent.json
+++ b/schema/components/schemas/ResponseReasoningDeltaStreamingEvent.json
@@ -2,9 +2,9 @@
   "properties": {
     "type": {
       "type": "string",
-      "enum": ["response.reasoning.delta"],
-      "description": "The type of the event, always `response.reasoning.delta`.",
-      "default": "response.reasoning.delta",
+      "enum": ["response.reasoning_text.delta"],
+      "description": "The type of the event, always `response.reasoning_text.delta`.",
+      "default": "response.reasoning_text.delta",
       "x-stainless-const": true
     },
     "sequence_number": {

--- a/schema/components/schemas/ResponseReasoningDoneStreamingEvent.json
+++ b/schema/components/schemas/ResponseReasoningDoneStreamingEvent.json
@@ -2,9 +2,9 @@
   "properties": {
     "type": {
       "type": "string",
-      "enum": ["response.reasoning.done"],
-      "description": "The type of the event, always `response.reasoning.done`.",
-      "default": "response.reasoning.done",
+      "enum": ["response.reasoning_text.done"],
+      "description": "The type of the event, always `response.reasoning_text.done`.",
+      "default": "response.reasoning_text.done",
       "x-stainless-const": true
     },
     "sequence_number": {

--- a/src/generated/kubb/zod/responseReasoningDeltaStreamingEventSchema.ts
+++ b/src/generated/kubb/zod/responseReasoningDeltaStreamingEventSchema.ts
@@ -11,9 +11,9 @@ import { z } from "zod";
 export const responseReasoningDeltaStreamingEventSchema = z
   .object({
     type: z
-      .enum(["response.reasoning.delta"])
-      .default("response.reasoning.delta")
-      .describe("The type of the event, always `response.reasoning.delta`."),
+      .enum(["response.reasoning_text.delta"])
+      .default("response.reasoning_text.delta")
+      .describe("The type of the event, always `response.reasoning_text.delta`."),
     sequence_number: z
       .number()
       .int()

--- a/src/generated/kubb/zod/responseReasoningDoneStreamingEventSchema.ts
+++ b/src/generated/kubb/zod/responseReasoningDoneStreamingEventSchema.ts
@@ -11,9 +11,9 @@ import { z } from "zod";
 export const responseReasoningDoneStreamingEventSchema = z
   .object({
     type: z
-      .enum(["response.reasoning.done"])
-      .default("response.reasoning.done")
-      .describe("The type of the event, always `response.reasoning.done`."),
+      .enum(["response.reasoning_text.done"])
+      .default("response.reasoning_text.done")
+      .describe("The type of the event, always `response.reasoning_text.done`."),
     sequence_number: z
       .number()
       .int()


### PR DESCRIPTION
The official OpenAPI specification for OpenAI 1P on stainless.com lists this discriminator as 'response.reasoning_text.delta'.  I imagine this hasn't caused issues testing against 1P because these blocks aren't typically returned.

While this is a breaking change technically speaking, I'm pretty confident this is a bug in the OpenResponses spec given other implementations also use this discriminator that do return reasoning (i.e. AWS).

Another common variant of this is 'response.reasoning_part.added' which is used by vLLM but I think supporting reasoning_text in OpenResponses makes the most sense.