### PR TITLE
Break out a new MessageItemParam type to capture role-based union

### DIFF
--- a/public/openapi/openapi.json
+++ b/public/openapi/openapi.json
@@ -24,7 +24,9 @@
             "anyOf": [
               {
                 "type": "string",
-                "enum": ["item_reference"],
+                "enum": [
+                  "item_reference"
+                ],
                 "description": "The type of item to reference. Always `item_reference`.",
                 "default": "item_reference"
               },
@@ -39,7 +41,9 @@
           }
         },
         "type": "object",
-        "required": ["id"],
+        "required": [
+          "id"
+        ],
         "title": "Item reference",
         "description": "An internal identifier for an item to reference."
       },
@@ -47,7 +51,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["summary_text"],
+            "enum": [
+              "summary_text"
+            ],
             "description": "The content type. Always `summary_text`.",
             "default": "summary_text"
           },
@@ -58,7 +64,10 @@
           }
         },
         "type": "object",
-        "required": ["type", "text"]
+        "required": [
+          "type",
+          "text"
+        ]
       },
       "ReasoningItemParam": {
         "properties": {
@@ -76,7 +85,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["reasoning"],
+            "enum": [
+              "reasoning"
+            ],
             "description": "The item type. Always `reasoning`.",
             "default": "reasoning"
           },
@@ -107,13 +118,18 @@
           }
         },
         "type": "object",
-        "required": ["type", "summary"]
+        "required": [
+          "type",
+          "summary"
+        ]
       },
       "InputTextContentParam": {
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["input_text"],
+            "enum": [
+              "input_text"
+            ],
             "description": "The type of the input item. Always `input_text`.",
             "default": "input_text"
           },
@@ -124,7 +140,10 @@
           }
         },
         "type": "object",
-        "required": ["type", "text"],
+        "required": [
+          "type",
+          "text"
+        ],
         "title": "Input text",
         "description": "A text input to the model.",
         "x-unionDisplay": "section",
@@ -132,7 +151,11 @@
       },
       "DetailEnum": {
         "type": "string",
-        "enum": ["low", "high", "auto"],
+        "enum": [
+          "low",
+          "high",
+          "auto"
+        ],
         "x-enumDescriptions": {
           "auto": "Choose the detail level automatically.",
           "high": "Allows the model to \"see\" a higher-resolution version of the image, usually increasing input token costs.",
@@ -143,7 +166,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["input_image"],
+            "enum": [
+              "input_image"
+            ],
             "description": "The type of the input item. Always `input_image`.",
             "default": "input_image"
           },
@@ -178,7 +203,9 @@
           }
         },
         "type": "object",
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "title": "Input image",
         "description": "An image input to the model. Learn about [image inputs](/docs/guides/vision)"
       },
@@ -186,7 +213,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["input_file"],
+            "enum": [
+              "input_file"
+            ],
             "description": "The type of the input item. Always `input_file`.",
             "default": "input_file"
           },
@@ -226,7 +255,9 @@
           }
         },
         "type": "object",
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "title": "Input file",
         "description": "A file input to the model."
       },
@@ -246,13 +277,17 @@
           },
           "type": {
             "type": "string",
-            "enum": ["message"],
+            "enum": [
+              "message"
+            ],
             "description": "The item type. Always `message`.",
             "default": "message"
           },
           "role": {
             "type": "string",
-            "enum": ["user"],
+            "enum": [
+              "user"
+            ],
             "description": "The message role. Always `user`.",
             "default": "user"
           },
@@ -299,7 +334,11 @@
           }
         },
         "type": "object",
-        "required": ["type", "role", "content"]
+        "required": [
+          "type",
+          "role",
+          "content"
+        ]
       },
       "SystemMessageItemParam": {
         "properties": {
@@ -317,13 +356,17 @@
           },
           "type": {
             "type": "string",
-            "enum": ["message"],
+            "enum": [
+              "message"
+            ],
             "description": "The item type. Always `message`.",
             "default": "message"
           },
           "role": {
             "type": "string",
-            "enum": ["system"],
+            "enum": [
+              "system"
+            ],
             "description": "The message role. Always `system`.",
             "default": "system"
           },
@@ -363,7 +406,11 @@
           }
         },
         "type": "object",
-        "required": ["type", "role", "content"]
+        "required": [
+          "type",
+          "role",
+          "content"
+        ]
       },
       "DeveloperMessageItemParam": {
         "properties": {
@@ -381,13 +428,17 @@
           },
           "type": {
             "type": "string",
-            "enum": ["message"],
+            "enum": [
+              "message"
+            ],
             "description": "The item type. Always `message`.",
             "default": "message"
           },
           "role": {
             "type": "string",
-            "enum": ["developer"],
+            "enum": [
+              "developer"
+            ],
             "description": "The message role. Always `developer`.",
             "default": "developer"
           },
@@ -427,13 +478,19 @@
           }
         },
         "type": "object",
-        "required": ["type", "role", "content"]
+        "required": [
+          "type",
+          "role",
+          "content"
+        ]
       },
       "UrlCitationParam": {
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["url_citation"],
+            "enum": [
+              "url_citation"
+            ],
             "description": "The citation type. Always `url_citation`.",
             "default": "url_citation"
           },
@@ -457,13 +514,21 @@
           }
         },
         "type": "object",
-        "required": ["type", "start_index", "end_index", "url", "title"]
+        "required": [
+          "type",
+          "start_index",
+          "end_index",
+          "url",
+          "title"
+        ]
       },
       "OutputTextContentParam": {
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["output_text"],
+            "enum": [
+              "output_text"
+            ],
             "description": "The content type. Always `output_text`.",
             "default": "output_text"
           },
@@ -485,13 +550,18 @@
           }
         },
         "type": "object",
-        "required": ["type", "text"]
+        "required": [
+          "type",
+          "text"
+        ]
       },
       "RefusalContentParam": {
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["refusal"],
+            "enum": [
+              "refusal"
+            ],
             "description": "The content type. Always `refusal`.",
             "default": "refusal"
           },
@@ -502,7 +572,10 @@
           }
         },
         "type": "object",
-        "required": ["type", "refusal"]
+        "required": [
+          "type",
+          "refusal"
+        ]
       },
       "AssistantMessageItemParam": {
         "properties": {
@@ -520,13 +593,17 @@
           },
           "type": {
             "type": "string",
-            "enum": ["message"],
+            "enum": [
+              "message"
+            ],
             "description": "The item type. Always `message`.",
             "default": "message"
           },
           "role": {
             "type": "string",
-            "enum": ["assistant"],
+            "enum": [
+              "assistant"
+            ],
             "description": "The role of the message author. Always `assistant`.",
             "default": "assistant"
           },
@@ -570,11 +647,48 @@
           }
         },
         "type": "object",
-        "required": ["type", "role", "content"]
+        "required": [
+          "type",
+          "role",
+          "content"
+        ]
+      },
+      "MessageItemParam": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/UserMessageItemParam"
+          },
+          {
+            "$ref": "#/components/schemas/SystemMessageItemParam"
+          },
+          {
+            "$ref": "#/components/schemas/DeveloperMessageItemParam"
+          },
+          {
+            "$ref": "#/components/schemas/AssistantMessageItemParam"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "role"
+        },
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "default": "message"
+          }
+        },
+        "description": "A message item with role-based discrimination."
       },
       "FunctionCallItemStatus": {
         "type": "string",
-        "enum": ["in_progress", "completed", "incomplete"]
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ]
       },
       "FunctionCallItemParam": {
         "properties": {
@@ -598,7 +712,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["function_call"],
+            "enum": [
+              "function_call"
+            ],
             "description": "The item type. Always `function_call`.",
             "default": "function_call"
           },
@@ -632,7 +748,12 @@
           }
         },
         "type": "object",
-        "required": ["call_id", "type", "name", "arguments"]
+        "required": [
+          "call_id",
+          "type",
+          "name",
+          "arguments"
+        ]
       },
       "FunctionCallOutputItemParam": {
         "properties": {
@@ -656,7 +777,9 @@
           },
           "type": {
             "type": "string",
-            "enum": ["function_call_output"],
+            "enum": [
+              "function_call_output"
+            ],
             "description": "The type of the function tool call output. Always `function_call_output`.",
             "default": "function_call_output"
           },
@@ -713,7 +836,11 @@
           }
         },
         "type": "object",
-        "required": ["call_id", "type", "output"],
+        "required": [
+          "call_id",
+          "type",
+          "output"
+        ],
         "title": "Function tool call output",
         "description": "The output of a function tool call."
       },
@@ -726,16 +853,7 @@
             "$ref": "#/components/schemas/ReasoningItemParam"
           },
           {
-            "$ref": "#/components/schemas/UserMessageItemParam"
-          },
-          {
-            "$ref": "#/components/schemas/SystemMessageItemParam"
-          },
-          {
-            "$ref": "#/components/schemas/DeveloperMessageItemParam"
-          },
-          {
-            "$ref": "#/components/schemas/AssistantMessageItemParam"
+            "$ref": "#/components/schemas/MessageItemParam"
           },
           {
             "$ref": "#/components/schemas/FunctionCallItemParam"
@@ -752,7 +870,10 @@
       },
       "IncludeEnum": {
         "type": "string",
-        "enum": ["reasoning.encrypted_content", "message.output_text.logprobs"],
+        "enum": [
+          "reasoning.encrypted_content",
+          "message.output_text.logprobs"
+        ],
         "description": "",
         "x-enumDescriptions": {
           "message.output_text.logprobs": "includes sampled logprobs in assistant messages.",
@@ -797,12 +918,17 @@
           },
           "type": {
             "type": "string",
-            "enum": ["function"],
+            "enum": [
+              "function"
+            ],
             "default": "function"
           }
         },
         "type": "object",
-        "required": ["name", "type"]
+        "required": [
+          "name",
+          "type"
+        ]
       },
       "ResponsesToolParam": {
         "oneOf": [
@@ -820,7 +946,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["function"],
+            "enum": [
+              "function"
+            ],
             "description": "The tool to call. Always `function`.",
             "default": "function"
           },
@@ -830,7 +958,10 @@
           }
         },
         "type": "object",
-        "required": ["type", "name"]
+        "required": [
+          "type",
+          "name"
+        ]
       },
       "SpecificToolChoiceParam": {
         "oneOf": [
@@ -841,7 +972,11 @@
       },
       "ToolChoiceValueEnum": {
         "type": "string",
-        "enum": ["none", "auto", "required"],
+        "enum": [
+          "none",
+          "auto",
+          "required"
+        ],
         "x-enumDescriptions": {
           "auto": "Let the model choose the tools from among the provided set.",
           "none": "Restrict the model from calling any tools.",
@@ -852,7 +987,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["allowed_tools"],
+            "enum": [
+              "allowed_tools"
+            ],
             "description": "The tool choice type. Always `allowed_tools`.",
             "default": "allowed_tools"
           },
@@ -877,7 +1014,10 @@
           }
         },
         "type": "object",
-        "required": ["type", "tools"]
+        "required": [
+          "type",
+          "tools"
+        ]
       },
       "ToolChoiceParam": {
         "oneOf": [
@@ -904,7 +1044,11 @@
       },
       "VerbosityEnum": {
         "type": "string",
-        "enum": ["low", "medium", "high"],
+        "enum": [
+          "low",
+          "medium",
+          "high"
+        ],
         "x-enumDescriptions": {
           "high": "Instruct the model to emit more verbose final responses.",
           "low": "Instruct the model to emit less verbose final responses.",
@@ -951,7 +1095,13 @@
       },
       "ReasoningEffortEnum": {
         "type": "string",
-        "enum": ["none", "low", "medium", "high", "xhigh"],
+        "enum": [
+          "none",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ],
         "x-enumDescriptions": {
           "high": "Use a higher reasoning effort to improve answer quality.",
           "medium": "Use a balanced reasoning effort.",
@@ -963,7 +1113,11 @@
       },
       "ReasoningSummaryEnum": {
         "type": "string",
-        "enum": ["concise", "detailed", "auto"],
+        "enum": [
+          "concise",
+          "detailed",
+          "auto"
+        ],
         "x-enumDescriptions": {
           "auto": "Allow the model to decide when to summarize.",
           "concise": "Emit concise summaries of reasoning content.",
@@ -1011,7 +1165,10 @@
       },
       "TruncationEnum": {
         "type": "string",
-        "enum": ["auto", "disabled"],
+        "enum": [
+          "auto",
+          "disabled"
+        ],
         "x-enumDescriptions": {
           "auto": "Let the service decide how to truncate.",
           "disabled": "Disable service truncation. Context over the model's context limit will result in a 400 error."
@@ -1019,7 +1176,12 @@
       },
       "ServiceTierEnum": {
         "type": "string",
-        "enum": ["auto", "default", "flex", "priority"],
+        "enum": [
+          "auto",
+          "default",
+          "flex",
+          "priority"
+        ],
         "x-enumDescriptions": {
           "auto": "Choose a service tier automatically based on current account state.",
           "default": "Choose the default service tier.",
@@ -1351,13 +1513,20 @@
           }
         },
         "type": "object",
-        "required": ["reason"],
+        "required": [
+          "reason"
+        ],
         "title": "Incomplete details",
         "description": "Details about why the response was incomplete."
       },
       "MessageRole": {
         "type": "string",
-        "enum": ["user", "assistant", "system", "developer"],
+        "enum": [
+          "user",
+          "assistant",
+          "system",
+          "developer"
+        ],
         "x-enumDescriptions": {
           "assistant": "Model-generated content in the conversation.",
           "developer": "Developer-supplied guidance that shapes the assistant\u2019s behavior.",
@@ -1369,7 +1538,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["input_text"],
+            "enum": [
+              "input_text"
+            ],
             "description": "The type of the input item. Always `input_text`.",
             "default": "input_text"
           },
@@ -1379,7 +1550,10 @@
           }
         },
         "type": "object",
-        "required": ["type", "text"],
+        "required": [
+          "type",
+          "text"
+        ],
         "title": "Input text",
         "description": "A text input to the model."
       },
@@ -1387,7 +1561,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["url_citation"],
+            "enum": [
+              "url_citation"
+            ],
             "description": "The type of the URL citation. Always `url_citation`.",
             "default": "url_citation"
           },
@@ -1409,7 +1585,13 @@
           }
         },
         "type": "object",
-        "required": ["type", "url", "start_index", "end_index", "title"],
+        "required": [
+          "type",
+          "url",
+          "start_index",
+          "end_index",
+          "title"
+        ],
         "title": "URL citation",
         "description": "A citation for a web resource used to generate a model response."
       },
@@ -1440,7 +1622,11 @@
           }
         },
         "type": "object",
-        "required": ["token", "logprob", "bytes"],
+        "required": [
+          "token",
+          "logprob",
+          "bytes"
+        ],
         "title": "Top log probability",
         "description": "The top log probability of a token."
       },
@@ -1466,7 +1652,12 @@
           }
         },
         "type": "object",
-        "required": ["token", "logprob", "bytes", "top_logprobs"],
+        "required": [
+          "token",
+          "logprob",
+          "bytes",
+          "top_logprobs"
+        ],
         "title": "Log probability",
         "description": "The log probability of a token."
       },
@@ -1474,7 +1665,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["output_text"],
+            "enum": [
+              "output_text"
+            ],
             "description": "The type of the output text. Always `output_text`.",
             "default": "output_text"
           },
@@ -1497,7 +1690,12 @@
           }
         },
         "type": "object",
-        "required": ["type", "text", "annotations", "logprobs"],
+        "required": [
+          "type",
+          "text",
+          "annotations",
+          "logprobs"
+        ],
         "title": "Output text",
         "description": "A text output from the model."
       },
@@ -1505,7 +1703,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["text"],
+            "enum": [
+              "text"
+            ],
             "default": "text"
           },
           "text": {
@@ -1513,7 +1713,10 @@
           }
         },
         "type": "object",
-        "required": ["type", "text"],
+        "required": [
+          "type",
+          "text"
+        ],
         "title": "Text Content",
         "description": "A text content."
       },
@@ -1521,7 +1724,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["summary_text"],
+            "enum": [
+              "summary_text"
+            ],
             "description": "The type of the object. Always `summary_text`.",
             "default": "summary_text"
           },
@@ -1531,7 +1736,10 @@
           }
         },
         "type": "object",
-        "required": ["type", "text"],
+        "required": [
+          "type",
+          "text"
+        ],
         "title": "Summary text",
         "description": "A summary text from the model."
       },
@@ -1539,7 +1747,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["reasoning_text"],
+            "enum": [
+              "reasoning_text"
+            ],
             "description": "The type of the reasoning text. Always `reasoning_text`.",
             "default": "reasoning_text"
           },
@@ -1549,7 +1759,10 @@
           }
         },
         "type": "object",
-        "required": ["type", "text"],
+        "required": [
+          "type",
+          "text"
+        ],
         "title": "Reasoning text",
         "description": "Reasoning text from the model."
       },
@@ -1557,7 +1770,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["refusal"],
+            "enum": [
+              "refusal"
+            ],
             "description": "The type of the refusal. Always `refusal`.",
             "default": "refusal"
           },
@@ -1567,13 +1782,20 @@
           }
         },
         "type": "object",
-        "required": ["type", "refusal"],
+        "required": [
+          "type",
+          "refusal"
+        ],
         "title": "Refusal",
         "description": "A refusal from the model."
       },
       "ImageDetail": {
         "type": "string",
-        "enum": ["low", "high", "auto"],
+        "enum": [
+          "low",
+          "high",
+          "auto"
+        ],
         "x-enumDescriptions": {
           "auto": "Choose the detail level automatically.",
           "high": "Allows the model to \"see\" a higher-resolution version of the image, usually increasing input token costs.",
@@ -1584,7 +1806,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["input_image"],
+            "enum": [
+              "input_image"
+            ],
             "description": "The type of the input item. Always `input_image`.",
             "default": "input_image"
           },
@@ -1611,7 +1835,11 @@
           }
         },
         "type": "object",
-        "required": ["type", "image_url", "detail"],
+        "required": [
+          "type",
+          "image_url",
+          "detail"
+        ],
         "title": "Input image",
         "description": "An image input to the model. Learn about [image inputs](/docs/guides/vision)."
       },
@@ -1619,7 +1847,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["input_file"],
+            "enum": [
+              "input_file"
+            ],
             "description": "The type of the input item. Always `input_file`.",
             "default": "input_file"
           },
@@ -1633,13 +1863,19 @@
           }
         },
         "type": "object",
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "title": "Input file",
         "description": "A file input to the model."
       },
       "MessageStatus": {
         "type": "string",
-        "enum": ["in_progress", "completed", "incomplete"],
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ],
         "x-enumDescriptions": {
           "completed": "Model has finished sampling this item.",
           "in_progress": "Model is currently sampling this item.",
@@ -1650,7 +1886,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["message"],
+            "enum": [
+              "message"
+            ],
             "description": "The type of the message. Always set to `message`.",
             "default": "message"
           },
@@ -1719,13 +1957,23 @@
           }
         },
         "type": "object",
-        "required": ["type", "id", "status", "role", "content"],
+        "required": [
+          "type",
+          "id",
+          "status",
+          "role",
+          "content"
+        ],
         "title": "Message",
         "description": "A message to or from the model."
       },
       "FunctionCallStatus": {
         "type": "string",
-        "enum": ["in_progress", "completed", "incomplete"],
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ],
         "x-enumDescriptions": {
           "completed": "Model has finished sampling this item.",
           "in_progress": "Model is currently sampling this item.",
@@ -1736,7 +1984,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["function_call"],
+            "enum": [
+              "function_call"
+            ],
             "description": "The type of the item. Always `function_call`.",
             "default": "function_call"
           },
@@ -1768,20 +2018,33 @@
           }
         },
         "type": "object",
-        "required": ["type", "id", "call_id", "name", "arguments", "status"],
+        "required": [
+          "type",
+          "id",
+          "call_id",
+          "name",
+          "arguments",
+          "status"
+        ],
         "title": "Function call",
         "description": "A function tool call that was generated by the model."
       },
       "FunctionCallOutputStatusEnum": {
         "type": "string",
-        "enum": ["in_progress", "completed", "incomplete"],
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ],
         "description": "Similar to `FunctionCallStatus`. All three options are allowed here for compatibility, but because in practice these items will be provided by developers, only `completed` should be used."
       },
       "FunctionCallOutput": {
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["function_call_output"],
+            "enum": [
+              "function_call_output"
+            ],
             "description": "The type of the function tool call output. Always `function_call_output`.",
             "default": "function_call_output"
           },
@@ -1834,7 +2097,13 @@
           }
         },
         "type": "object",
-        "required": ["type", "id", "call_id", "output", "status"],
+        "required": [
+          "type",
+          "id",
+          "call_id",
+          "output",
+          "status"
+        ],
         "title": "Function call output",
         "description": "A function tool call output that was returned by the tool."
       },
@@ -1842,7 +2111,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["reasoning"],
+            "enum": [
+              "reasoning"
+            ],
             "description": "The type of the item. Always `reasoning`.",
             "default": "reasoning"
           },
@@ -1928,7 +2199,11 @@
           }
         },
         "type": "object",
-        "required": ["type", "id", "summary"],
+        "required": [
+          "type",
+          "id",
+          "summary"
+        ],
         "title": "Reasoning item",
         "description": "A reasoning item that was generated by the model."
       },
@@ -1964,7 +2239,10 @@
           }
         },
         "type": "object",
-        "required": ["code", "message"],
+        "required": [
+          "code",
+          "message"
+        ],
         "title": "Error",
         "description": "An error that occurred while generating the response."
       },
@@ -1972,7 +2250,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["function"],
+            "enum": [
+              "function"
+            ],
             "description": "The type of the function tool. Always `function`.",
             "default": "function"
           },
@@ -2016,7 +2296,13 @@
           }
         },
         "type": "object",
-        "required": ["type", "name", "description", "parameters", "strict"],
+        "required": [
+          "type",
+          "name",
+          "description",
+          "parameters",
+          "strict"
+        ],
         "title": "Function",
         "description": "Defines a function in your own code the model can choose to call. Learn more about [function calling](https://platform.openai.com/docs/guides/function-calling)."
       },
@@ -2035,7 +2321,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["function"],
+            "enum": [
+              "function"
+            ],
             "default": "function"
           },
           "name": {
@@ -2043,13 +2331,17 @@
           }
         },
         "type": "object",
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "AllowedToolChoice": {
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["allowed_tools"],
+            "enum": [
+              "allowed_tools"
+            ],
             "default": "allowed_tools"
           },
           "tools": {
@@ -2067,35 +2359,49 @@
           }
         },
         "type": "object",
-        "required": ["type", "tools", "mode"]
+        "required": [
+          "type",
+          "tools",
+          "mode"
+        ]
       },
       "TextResponseFormat": {
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["text"],
+            "enum": [
+              "text"
+            ],
             "default": "text"
           }
         },
         "type": "object",
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "JsonObjectResponseFormat": {
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["json_object"],
+            "enum": [
+              "json_object"
+            ],
             "default": "json_object"
           }
         },
         "type": "object",
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "JsonSchemaResponseFormat": {
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["json_schema"],
+            "enum": [
+              "json_schema"
+            ],
             "default": "json_schema"
           },
           "name": {
@@ -2123,7 +2429,13 @@
           }
         },
         "type": "object",
-        "required": ["type", "name", "description", "schema", "strict"]
+        "required": [
+          "type",
+          "name",
+          "description",
+          "schema",
+          "strict"
+        ]
       },
       "TextField": {
         "properties": {
@@ -2145,7 +2457,9 @@
           }
         },
         "type": "object",
-        "required": ["format"]
+        "required": [
+          "format"
+        ]
       },
       "Reasoning": {
         "properties": {
@@ -2183,7 +2497,10 @@
           }
         },
         "type": "object",
-        "required": ["effort", "summary"],
+        "required": [
+          "effort",
+          "summary"
+        ],
         "title": "Reasoning",
         "description": "Reasoning configuration and metadata that were used for the response."
       },
@@ -2195,7 +2512,9 @@
           }
         },
         "type": "object",
-        "required": ["cached_tokens"],
+        "required": [
+          "cached_tokens"
+        ],
         "title": "Input tokens details",
         "description": "A breakdown of input token usage that was recorded."
       },
@@ -2207,7 +2526,9 @@
           }
         },
         "type": "object",
-        "required": ["reasoning_tokens"],
+        "required": [
+          "reasoning_tokens"
+        ],
         "title": "Output tokens details",
         "description": "A breakdown of output token usage that was recorded."
       },
@@ -2265,7 +2586,9 @@
           },
           "object": {
             "type": "string",
-            "enum": ["response"],
+            "enum": [
+              "response"
+            ],
             "description": "The object type, which was always `response`.",
             "default": "response"
           },
@@ -2611,7 +2934,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.created"],
+            "enum": [
+              "response.created"
+            ],
             "description": "The type of the event, always `response.created`.",
             "default": "response.created"
           },
@@ -2631,7 +2956,11 @@
           }
         },
         "type": "object",
-        "required": ["type", "sequence_number", "response"],
+        "required": [
+          "type",
+          "sequence_number",
+          "response"
+        ],
         "title": "Response created event",
         "description": "A streaming event that indicated the response was created."
       },
@@ -2639,7 +2968,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.queued"],
+            "enum": [
+              "response.queued"
+            ],
             "description": "The type of the event, always `response.queued`.",
             "default": "response.queued"
           },
@@ -2659,7 +2990,11 @@
           }
         },
         "type": "object",
-        "required": ["type", "sequence_number", "response"],
+        "required": [
+          "type",
+          "sequence_number",
+          "response"
+        ],
         "title": "Response queued event",
         "description": "A streaming event that indicated the response was queued."
       },
@@ -2667,7 +3002,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.in_progress"],
+            "enum": [
+              "response.in_progress"
+            ],
             "description": "The type of the event, always `response.in_progress`.",
             "default": "response.in_progress"
           },
@@ -2687,7 +3024,11 @@
           }
         },
         "type": "object",
-        "required": ["type", "sequence_number", "response"],
+        "required": [
+          "type",
+          "sequence_number",
+          "response"
+        ],
         "title": "Response in progress event",
         "description": "A streaming event that indicated the response was in progress."
       },
@@ -2695,7 +3036,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.completed"],
+            "enum": [
+              "response.completed"
+            ],
             "description": "The type of the event, always `response.completed`.",
             "default": "response.completed"
           },
@@ -2715,7 +3058,11 @@
           }
         },
         "type": "object",
-        "required": ["type", "sequence_number", "response"],
+        "required": [
+          "type",
+          "sequence_number",
+          "response"
+        ],
         "title": "Response completed event",
         "description": "A streaming event that indicated the response was completed."
       },
@@ -2723,7 +3070,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.failed"],
+            "enum": [
+              "response.failed"
+            ],
             "description": "The type of the event, always `response.failed`.",
             "default": "response.failed"
           },
@@ -2743,7 +3092,11 @@
           }
         },
         "type": "object",
-        "required": ["type", "sequence_number", "response"],
+        "required": [
+          "type",
+          "sequence_number",
+          "response"
+        ],
         "title": "Response failed event",
         "description": "A streaming event that indicated the response had failed."
       },
@@ -2751,7 +3104,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.incomplete"],
+            "enum": [
+              "response.incomplete"
+            ],
             "description": "The type of the event, always `response.incomplete`.",
             "default": "response.incomplete"
           },
@@ -2771,7 +3126,11 @@
           }
         },
         "type": "object",
-        "required": ["type", "sequence_number", "response"],
+        "required": [
+          "type",
+          "sequence_number",
+          "response"
+        ],
         "title": "Response incomplete event",
         "description": "A streaming event that indicated the response was incomplete."
       },
@@ -2779,7 +3138,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.output_item.added"],
+            "enum": [
+              "response.output_item.added"
+            ],
             "description": "The type of the event, always `response.output_item.added`.",
             "default": "response.output_item.added"
           },
@@ -2810,7 +3171,12 @@
           }
         },
         "type": "object",
-        "required": ["type", "sequence_number", "output_index", "item"],
+        "required": [
+          "type",
+          "sequence_number",
+          "output_index",
+          "item"
+        ],
         "title": "Response output item added event",
         "description": "A streaming event that indicated an output item was added to the response."
       },
@@ -2818,7 +3184,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.output_item.done"],
+            "enum": [
+              "response.output_item.done"
+            ],
             "description": "The type of the event, always `response.output_item.done`.",
             "default": "response.output_item.done"
           },
@@ -2849,7 +3217,12 @@
           }
         },
         "type": "object",
-        "required": ["type", "sequence_number", "output_index", "item"],
+        "required": [
+          "type",
+          "sequence_number",
+          "output_index",
+          "item"
+        ],
         "title": "Response output item done event",
         "description": "A streaming event that indicated an output item was completed."
       },
@@ -2857,7 +3230,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.reasoning_summary_part.added"],
+            "enum": [
+              "response.reasoning_summary_part.added"
+            ],
             "description": "The type of the event, always `response.reasoning_summary_part.added`.",
             "default": "response.reasoning_summary_part.added"
           },
@@ -2926,7 +3301,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.reasoning_summary_part.done"],
+            "enum": [
+              "response.reasoning_summary_part.done"
+            ],
             "description": "The type of the event, always `response.reasoning_summary_part.done`.",
             "default": "response.reasoning_summary_part.done"
           },
@@ -2995,7 +3372,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.content_part.added"],
+            "enum": [
+              "response.content_part.added"
+            ],
             "description": "The type of the event, always `response.content_part.added`.",
             "default": "response.content_part.added"
           },
@@ -3064,7 +3443,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.content_part.done"],
+            "enum": [
+              "response.content_part.done"
+            ],
             "description": "The type of the event, always `response.content_part.done`.",
             "default": "response.content_part.done"
           },
@@ -3133,7 +3514,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.output_text.delta"],
+            "enum": [
+              "response.output_text.delta"
+            ],
             "description": "The type of the event, always `response.output_text.delta`.",
             "default": "response.output_text.delta"
           },
@@ -3186,7 +3569,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.output_text.done"],
+            "enum": [
+              "response.output_text.done"
+            ],
             "description": "The type of the event, always `response.output_text.done`.",
             "default": "response.output_text.done"
           },
@@ -3235,7 +3620,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.refusal.delta"],
+            "enum": [
+              "response.refusal.delta"
+            ],
             "description": "The type of the event, always `response.refusal.delta`.",
             "default": "response.refusal.delta"
           },
@@ -3276,7 +3663,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.refusal.done"],
+            "enum": [
+              "response.refusal.done"
+            ],
             "description": "The type of the event, always `response.refusal.done`.",
             "default": "response.refusal.done"
           },
@@ -3317,7 +3706,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.reasoning.delta"],
+            "enum": [
+              "response.reasoning.delta"
+            ],
             "description": "The type of the event, always `response.reasoning.delta`.",
             "default": "response.reasoning.delta"
           },
@@ -3362,7 +3753,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.reasoning.done"],
+            "enum": [
+              "response.reasoning.done"
+            ],
             "description": "The type of the event, always `response.reasoning.done`.",
             "default": "response.reasoning.done"
           },
@@ -3403,7 +3796,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.reasoning_summary_text.delta"],
+            "enum": [
+              "response.reasoning_summary_text.delta"
+            ],
             "description": "The type of the event, always `response.reasoning_summary.delta`.",
             "default": "response.reasoning_summary_text.delta"
           },
@@ -3448,7 +3843,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.reasoning_summary_text.done"],
+            "enum": [
+              "response.reasoning_summary_text.done"
+            ],
             "description": "The type of the event, always `response.reasoning_summary.done`.",
             "default": "response.reasoning_summary_text.done"
           },
@@ -3489,7 +3886,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.output_text.annotation.added"],
+            "enum": [
+              "response.output_text.annotation.added"
+            ],
             "description": "The type of the event, always `response.output_text.annotation.added`.",
             "default": "response.output_text.annotation.added"
           },
@@ -3548,7 +3947,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.function_call_arguments.delta"],
+            "enum": [
+              "response.function_call_arguments.delta"
+            ],
             "description": "The type of the event, always `response.function_call_arguments.delta`.",
             "default": "response.function_call_arguments.delta"
           },
@@ -3588,7 +3989,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["response.function_call_arguments.done"],
+            "enum": [
+              "response.function_call_arguments.done"
+            ],
             "description": "The type of the event, always `response.function_call_arguments.done`.",
             "default": "response.function_call_arguments.done"
           },
@@ -3662,7 +4065,12 @@
           }
         },
         "type": "object",
-        "required": ["type", "code", "message", "param"],
+        "required": [
+          "type",
+          "code",
+          "message",
+          "param"
+        ],
         "title": "Error payload",
         "description": "An error payload that was emitted for a streaming error event."
       },
@@ -3670,7 +4078,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["error"],
+            "enum": [
+              "error"
+            ],
             "description": "The type of the event, always `error`.",
             "default": "error"
           },
@@ -3690,7 +4100,11 @@
           }
         },
         "type": "object",
-        "required": ["type", "sequence_number", "error"],
+        "required": [
+          "type",
+          "sequence_number",
+          "error"
+        ],
         "title": "Error event",
         "description": "A streaming event that indicated an error was emitted."
       },
@@ -3700,7 +4114,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["input_video"],
+            "enum": [
+              "input_video"
+            ],
             "description": "The type of the input content. Always `input_video`."
           },
           "video_url": {
@@ -3708,7 +4124,10 @@
             "description": "A base64 or remote url that resolves to a video file."
           }
         },
-        "required": ["type", "video_url"]
+        "required": [
+          "type",
+          "video_url"
+        ]
       },
       "JsonSchemaResponseFormatParam": {
         "type": "object",
@@ -3716,7 +4135,9 @@
           "type": {
             "type": "string",
             "description": "The type of response format being defined. Always `json_schema`.",
-            "enum": ["json_schema"]
+            "enum": [
+              "json_schema"
+            ]
           },
           "description": {
             "type": "string",

--- a/schema/components/schemas/ItemParam.json
+++ b/schema/components/schemas/ItemParam.json
@@ -10,16 +10,7 @@
       "$ref": "./CompactionSummaryItemParam.json"
     },
     {
-      "$ref": "./UserMessageItemParam.json"
-    },
-    {
-      "$ref": "./SystemMessageItemParam.json"
-    },
-    {
-      "$ref": "./DeveloperMessageItemParam.json"
-    },
-    {
-      "$ref": "./AssistantMessageItemParam.json"
+      "$ref": "./MessageItemParam.json"
     },
     {
       "$ref": "./FunctionCallItemParam.json"

--- a/schema/components/schemas/MessageItemParam.json
+++ b/schema/components/schemas/MessageItemParam.json
@@ -1,0 +1,19 @@
+{
+  "oneOf": [
+    { "$ref": "./UserMessageItemParam.json" },
+    { "$ref": "./SystemMessageItemParam.json" },
+    { "$ref": "./DeveloperMessageItemParam.json" },
+    { "$ref": "./AssistantMessageItemParam.json" }
+  ],
+  "discriminator": {
+    "propertyName": "role"
+  },
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["message"],
+      "default": "message"
+    }
+  },
+  "description": "A message item with role-based discrimination."
+}

--- a/schema/openapi_filter_manifest.yaml
+++ b/schema/openapi_filter_manifest.yaml
@@ -58,10 +58,7 @@ allow:
     ItemParam:
       - ItemReferenceParam
       - ReasoningItemParam
-      - UserMessageItemParam
-      - SystemMessageItemParam
-      - DeveloperMessageItemParam
-      - AssistantMessageItemParam
+      - MessageItemParam
       - FunctionCallItemParam
       - FunctionCallOutputItemParam
     Tool:


### PR DESCRIPTION
Right now ItemParams are challenging to represent because they use the "type" parameter as a discriminator but then have multiple types that use type=message but then use a separate "role" parameter as a discriminator (i.e. AssistantMessageItem vs. UserMessageItem).

This can be cleanly represented by a combination of allOf and another separate type that explicitly uses "role" as the discriminator for oneOf.

I understand this might have some SDK ramifications but this allows for clean representation in more strongly typed languages like Rust.