### PR TITLE
fix(docs): address inconsistency in specification for request content…

### DIFF
--- a/src/pages/specification.mdx
+++ b/src/pages/specification.mdx
@@ -69,7 +69,7 @@ All messages MUST follow the HTTP protocol.
 
 **HTTP Request Bodies**
 
-Clients MUST send request bodies encoded as `application/json`
+Clients MUST send request bodies encoded as either `application/json` or `application/x-www-form-urlencoded`
 
 ## HTTP Responses
 


### PR DESCRIPTION
## Fix documentation inconsistency for request content types

### Summary
Fixed incorrect requirement in specification.mdx stating clients MUST send only `application/json`. Updated to correctly reflect that both `application/json` and `application/x-www-form-urlencoded` are supported.

### Changes
- Updated specification.mdx to match the OpenAPI spec and reference.mdx documentation

### Details
The OpenAPI spec (openapi.json:3770-3779) defines the `POST /responses` endpoint as accepting both content types, and reference.mdx correctly documented this. The specification page had an overly restrictive MUST requirement that contradicted the actual API behavior.
