### PR TITLE
Add @openresponses/state-machine package with buffered stream-through

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,18 @@
         "typescript": "^5.9.3",
       },
     },
+    "state-machines/typescript": {
+      "name": "@openresponses/state-machine",
+      "version": "0.1.0",
+      "dependencies": {
+        "robot3": "^1.2.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.9.3",
+      },
+    },
   },
   "packages": {
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
@@ -276,6 +288,8 @@
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
     "@mermaid-js/parser": ["@mermaid-js/parser@0.6.3", "", { "dependencies": { "langium": "3.3.1" } }, "sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA=="],
+
+    "@openresponses/state-machine": ["@openresponses/state-machine@workspace:state-machines/typescript"],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
@@ -539,6 +553,8 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
@@ -585,7 +601,11 @@
 
     "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
+    "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
+
     "bytes": ["bytes@3.0.0", "", {}, "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
     "call-me-maybe": ["call-me-maybe@1.0.2", "", {}, "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="],
 
@@ -885,6 +905,8 @@
 
     "find-up": ["find-up@7.0.0", "", { "dependencies": { "locate-path": "^7.2.0", "path-exists": "^5.0.0", "unicorn-magic": "^0.1.0" } }, "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g=="],
 
+    "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
+
     "flattie": ["flattie@1.1.1", "", {}, "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="],
 
     "fontace": ["fontace@0.3.1", "", { "dependencies": { "@types/fontkit": "^2.0.8", "fontkit": "^2.0.4" } }, "sha512-9f5g4feWT1jWT8+SbL85aLIRLIXUaDygaM2xPXRmzPYxrOMNok79Lr3FGJoKVNKibE0WCunNiEVG2mwuE+2qEg=="],
@@ -1007,6 +1029,8 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
     "js-levenshtein": ["js-levenshtein@1.1.6", "", {}, "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="],
 
     "js-runtime": ["js-runtime@0.0.8", "", {}, "sha512-/nxfuHRkzajgNgGP/7j2A9y8k54XtTWizq+vEGrWh3eBWlSqFhwgToXHAGZeHX3wRMTC3VFBw1iVeemlX4qxZw=="],
@@ -1079,11 +1103,15 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.30.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw=="],
 
+    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
     "lint-staged": ["lint-staged@16.2.7", "", { "dependencies": { "commander": "^14.0.2", "listr2": "^9.0.5", "micromatch": "^4.0.8", "nano-spawn": "^2.0.0", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.8.1" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow=="],
 
     "listr2": ["listr2@9.0.5", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g=="],
+
+    "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
 
     "locate-path": ["locate-path@7.2.0", "", { "dependencies": { "p-locate": "^6.0.0" } }, "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA=="],
 
@@ -1241,6 +1269,8 @@
 
     "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
 
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
     "nano-spawn": ["nano-spawn@2.0.0", "", {}, "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -1284,6 +1314,8 @@
     "oas-schema-walker": ["oas-schema-walker@1.1.5", "", {}, "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ=="],
 
     "oas-validator": ["oas-validator@5.0.8", "", { "dependencies": { "call-me-maybe": "^1.0.1", "oas-kit-common": "^1.0.8", "oas-linter": "^3.2.2", "oas-resolver": "^2.5.6", "oas-schema-walker": "^1.1.5", "reftools": "^1.1.9", "should": "^13.2.1", "yaml": "^1.10.0" } }, "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "ofetch": ["ofetch@1.5.1", "", { "dependencies": { "destr": "^2.0.5", "node-fetch-native": "^1.6.7", "ufo": "^1.6.1" } }, "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA=="],
 
@@ -1343,6 +1375,8 @@
 
     "pidtree": ["pidtree@0.6.0", "", { "bin": { "pidtree": "bin/pidtree.js" } }, "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g=="],
 
+    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
@@ -1352,6 +1386,8 @@
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
+    "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
 
     "postcss-nested": ["postcss-nested@6.2.0", "", { "dependencies": { "postcss-selector-parser": "^6.1.1" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ=="],
 
@@ -1445,7 +1481,7 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
-    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
@@ -1460,6 +1496,8 @@
     "retext-stringify": ["retext-stringify@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unified": "^11.0.0" } }, "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA=="],
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "robot3": ["robot3@1.2.0", "", {}, "sha512-Xin8KHqCKrD9Rqk1ZzZQYjsb6S9DRggcfwBqnVPeM3DLtNCJLxWWTrPJDYm3E+ZiTO7H3VMdgyPSkIbuYnYP2Q=="],
 
     "robust-predicates": ["robust-predicates@3.0.2", "", {}, "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="],
 
@@ -1541,6 +1579,8 @@
 
     "stylis": ["stylis@4.3.6", "", {}, "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ=="],
 
+    "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
+
     "suf-log": ["suf-log@2.5.3", "", { "dependencies": { "s.color": "0.0.15" } }, "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow=="],
 
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
@@ -1552,6 +1592,10 @@
     "tailwindcss": ["tailwindcss@4.1.18", "", {}, "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="],
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
     "timers-ext": ["timers-ext@0.1.8", "", { "dependencies": { "es5-ext": "^0.10.64", "next-tick": "^1.1.0" } }, "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww=="],
 
@@ -1579,9 +1623,13 @@
 
     "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
 
+    "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
     "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsup": ["tsup@8.5.1", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.27.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "^0.7.6", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing=="],
 
     "type": ["type@2.7.3", "", {}, "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ=="],
 
@@ -1789,6 +1837,8 @@
 
     "gradient-string/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "log-update/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
@@ -1819,9 +1869,15 @@
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
+    "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "swagger2openapi/yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
+
+    "tsup/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "tsup/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "widest-line/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -1856,6 +1912,58 @@
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
     "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "tsup/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "tsup/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "tsup/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "tsup/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "tsup/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "tsup/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "tsup/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "tsup/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "tsup/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "tsup/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "tsup/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "tsup/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "tsup/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "tsup/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "tsup/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "tsup/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "tsup/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "tsup/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "tsup/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "tsup/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "tsup/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "tsup/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "tsup/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "tsup/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "tsup/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "tsup/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
     "widest-line/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "OpenResponses",
   "main": "index.js",
+  "workspaces": [
+    "state-machines/typescript"
+  ],
   "scripts": {
     "tsp": "tsp compile schema__tsp/schema.tsp",
     "tsp:watch": "tsp compile schema__tsp/schema.tsp --watch",

--- a/src/lib/compliance-tests.ts
+++ b/src/lib/compliance-tests.ts
@@ -2,6 +2,8 @@ import type { z } from "zod";
 import type { createResponseBodySchema } from "../generated/kubb/zod/createResponseBodySchema";
 import { responseResourceSchema } from "../generated/kubb/zod/responseResourceSchema";
 import { parseSSEStream, type SSEParseResult } from "./sse-parser";
+import { ResponseStreamValidator } from "../../state-machines/typescript/src/index";
+import type { StreamingEvent as StateMachineEvent } from "../../state-machines/typescript/src/types";
 
 type ResponseResource = z.infer<typeof responseResourceSchema>;
 type CreateResponseBody = z.infer<typeof createResponseBodySchema>;
@@ -82,6 +84,29 @@ const streamingSchema: ResponseValidator = (_, context) => {
   return context.sseResult.errors;
 };
 
+const streamingEventOrder: ResponseValidator = (_, context) => {
+  if (!context.streaming || !context.sseResult) return [];
+
+  const validator = new ResponseStreamValidator();
+
+  for (const parsedEvent of context.sseResult.events) {
+    if (parsedEvent.validationResult.success) {
+      // Kubb-generated StreamingEvent is a structural superset of the
+      // state machine's minimal StreamingEvent union — cast is safe.
+      validator.send(
+        parsedEvent.validationResult.data as unknown as StateMachineEvent,
+      );
+    }
+  }
+
+  validator.finalize();
+
+  return validator.violations.map(
+    (v) =>
+      `[${v.rule}] ${v.message} (state: '${v.currentState}', event: '${v.event.type}')`,
+  );
+};
+
 export const testTemplates: TestTemplate[] = [
   {
     id: "basic-response",
@@ -103,13 +128,61 @@ export const testTemplates: TestTemplate[] = [
   {
     id: "streaming-response",
     name: "Streaming Response",
-    description: "Validates SSE streaming events and final response",
+    description:
+      "Validates SSE streaming events and final response without tools",
     streaming: true,
     getRequest: (config) => ({
       model: config.model,
       input: [{ type: "message", role: "user", content: "Count from 1 to 5." }],
     }),
-    validators: [streamingEvents, streamingSchema, completedStatus],
+    validators: [
+      streamingEvents,
+      streamingSchema,
+      streamingEventOrder,
+      completedStatus,
+    ],
+  },
+
+  {
+    id: "streaming-tool-call",
+    name: "Streaming Tool Call",
+    description:
+      "Validates SSE event ordering when a tool call is emitted mid-stream",
+    streaming: true,
+    getRequest: (config) => ({
+      model: config.model,
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: "What's the weather like in San Francisco?",
+        },
+      ],
+      tools: [
+        {
+          type: "function",
+          name: "get_weather",
+          description: "Get the current weather for a location",
+          parameters: {
+            type: "object",
+            properties: {
+              location: {
+                type: "string",
+                description: "The city and state, e.g. San Francisco, CA",
+              },
+            },
+            required: ["location"],
+          },
+        },
+      ],
+      tool_choice: { type: "function", name: "get_weather" },
+    }),
+    validators: [
+      streamingEvents,
+      streamingSchema,
+      streamingEventOrder,
+      hasOutputType("function_call"),
+    ],
   },
 
   {

--- a/state-machines/typescript/examples/custom-adapter.ts
+++ b/state-machines/typescript/examples/custom-adapter.ts
@@ -1,0 +1,110 @@
+/**
+ * custom-adapter.ts
+ *
+ * Documented example of a Redis-backed BufferAdapter.
+ *
+ * This file is illustrative — it does NOT run directly because it requires a
+ * real Redis client.  Replace `redisClient` with your actual client instance
+ * (ioredis, node-redis, Upstash, etc.).
+ *
+ * Key design notes
+ * ----------------
+ * • Use a per-response key so concurrent responses never share a buffer.
+ * • RPUSH / LPUSH + LRANGE gives O(1) enqueue and O(N) drain — acceptable
+ *   because N is bounded by the number of early events.
+ * • Set a TTL on the key so abandoned buffers do not leak memory.
+ * • For strict atomicity on drainAll, wrap LRANGE + DEL in a Lua script or
+ *   a pipeline so no events are lost if the process crashes between the two
+ *   commands.
+ */
+
+import type { BufferAdapter } from "../src/buffer.ts";
+import type { StreamingEvent } from "../src/types.ts";
+import { createResponseStream } from "../src/stream-processor.ts";
+
+// ---------------------------------------------------------------------------
+// RedisBufferAdapter
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface for the Redis commands this adapter needs.
+ * Compatible with ioredis, node-redis, and most other clients.
+ */
+interface RedisClient {
+  rpush(key: string, ...values: string[]): Promise<number>;
+  lrange(key: string, start: number, stop: number): Promise<string[]>;
+  del(key: string): Promise<number>;
+  lpush(key: string, ...values: string[]): Promise<number>;
+  expire(key: string, seconds: number): Promise<number>;
+}
+
+export class RedisBufferAdapter implements BufferAdapter {
+  private readonly key: string;
+  private readonly ttlSeconds: number;
+
+  /**
+   * @param client      - Your Redis client instance
+   * @param responseId  - Unique identifier for this response stream
+   * @param ttlSeconds  - How long to keep the key if the stream is abandoned (default: 300s)
+   */
+  constructor(
+    private readonly client: RedisClient,
+    responseId: string,
+    ttlSeconds = 300,
+  ) {
+    // Namespaced key: stream:<responseId>:buffer
+    this.key = `stream:${responseId}:buffer`;
+    this.ttlSeconds = ttlSeconds;
+  }
+
+  async enqueue(event: StreamingEvent): Promise<void> {
+    const serialized = JSON.stringify(event);
+    await this.client.rpush(this.key, serialized);
+    // Refresh TTL on each write so long-running streams stay alive.
+    await this.client.expire(this.key, this.ttlSeconds);
+  }
+
+  async drainAll(): Promise<StreamingEvent[]> {
+    // Atomicity note: for production use, replace the two calls below with a
+    // Lua script so the list cannot receive new items between LRANGE and DEL.
+    //
+    //   local items = redis.call('LRANGE', KEYS[1], 0, -1)
+    //   redis.call('DEL', KEYS[1])
+    //   return items
+    const items = await this.client.lrange(this.key, 0, -1);
+    if (items.length > 0) {
+      await this.client.del(this.key);
+    }
+    return items.map((s) => JSON.parse(s) as StreamingEvent);
+  }
+
+  async requeueAll(events: StreamingEvent[]): Promise<void> {
+    if (events.length === 0) return;
+    // LPUSH prepends in reverse order; push in reverse so final order is preserved.
+    const serialized = events.map((e) => JSON.stringify(e)).reverse();
+    await this.client.lpush(this.key, ...serialized);
+    await this.client.expire(this.key, this.ttlSeconds);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Usage sketch (not executed — illustrative only)
+// ---------------------------------------------------------------------------
+
+async function exampleUsage(
+  redisClient: RedisClient,
+  responseId: string,
+  incomingEvents: AsyncIterable<StreamingEvent>,
+) {
+  const adapter = new RedisBufferAdapter(redisClient, responseId);
+  const reordered = createResponseStream(incomingEvents, { buffer: adapter });
+
+  for await (const event of reordered) {
+    // Forward the correctly-ordered event downstream (e.g. to a WebSocket,
+    // a database, or a validation layer).
+    console.log(event.type);
+  }
+}
+
+// Keep TypeScript happy — exampleUsage is exported for documentation purposes.
+export { exampleUsage };

--- a/state-machines/typescript/examples/in-memory-buffer.ts
+++ b/state-machines/typescript/examples/in-memory-buffer.ts
@@ -1,0 +1,113 @@
+/**
+ * in-memory-buffer.ts
+ *
+ * End-to-end example: take an out-of-order sequence of StreamingEvents,
+ * reorder them with createResponseStream + InMemoryBufferAdapter, then
+ * validate the output with ResponseStreamValidator.
+ *
+ * Run: bun run state-machines/typescript/examples/in-memory-buffer.ts
+ */
+
+import {
+  createResponseStream,
+  InMemoryBufferAdapter,
+  ResponseStreamValidator,
+} from "../src/index.ts";
+import type { StreamingEvent } from "../src/types.ts";
+
+// ---------------------------------------------------------------------------
+// Build an intentionally out-of-order event stream
+// ---------------------------------------------------------------------------
+
+const outOfOrderEvents: StreamingEvent[] = [
+  { type: "response.created", sequence_number: 1 },
+  { type: "response.in_progress", sequence_number: 2 },
+
+  // These three arrive before their gateway events:
+  {
+    type: "response.output_text.delta",
+    item_id: "item-1",
+    output_index: 0,
+    content_index: 0,
+    sequence_number: 3,
+  },
+  {
+    type: "response.content_part.added",
+    item_id: "item-1",
+    output_index: 0,
+    content_index: 0,
+    sequence_number: 4,
+  },
+  // ^ content_part.added itself arrives before output_item.added
+
+  // Gateway events arrive "late":
+  {
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { id: "item-1" },
+    sequence_number: 5,
+  },
+
+  // These arrive in order relative to the reordered stream:
+  {
+    type: "response.output_text.done",
+    item_id: "item-1",
+    output_index: 0,
+    content_index: 0,
+    sequence_number: 6,
+  },
+  {
+    type: "response.content_part.done",
+    item_id: "item-1",
+    output_index: 0,
+    content_index: 0,
+    sequence_number: 7,
+  },
+  {
+    type: "response.output_item.done",
+    output_index: 0,
+    item: { id: "item-1", status: "completed" },
+    sequence_number: 8,
+  },
+  { type: "response.completed", sequence_number: 9 },
+];
+
+async function* fromArray(arr: StreamingEvent[]) {
+  for (const event of arr) yield event;
+}
+
+// ---------------------------------------------------------------------------
+// Reorder and validate
+// ---------------------------------------------------------------------------
+
+const buffer = new InMemoryBufferAdapter();
+const reorderedStream = createResponseStream(fromArray(outOfOrderEvents), {
+  buffer,
+});
+const validator = new ResponseStreamValidator();
+
+console.log("--- Reordered events ---");
+let eventIndex = 0;
+for await (const event of reorderedStream) {
+  eventIndex++;
+  const result = validator.send(event);
+  const status = result.valid
+    ? "✓"
+    : `✗ [${result.violations.map((v) => v.rule).join(", ")}]`;
+  console.log(
+    `  ${String(eventIndex).padStart(2)}. ${event.type.padEnd(40)} ${status}`,
+  );
+}
+
+const finalResult = validator.finalize();
+console.log("\n--- Final validation ---");
+if (finalResult.valid) {
+  console.log("✓ Stream is fully valid — no violations.");
+} else {
+  console.log("✗ Finalize violations:");
+  for (const v of finalResult.violations) {
+    console.log(`    [${v.rule}] ${v.message}`);
+  }
+}
+
+console.log(`\nAll violations: ${validator.violations.length}`);

--- a/state-machines/typescript/package.json
+++ b/state-machines/typescript/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@openresponses/state-machine",
+  "version": "0.1.0",
+  "description": "State machine validator for OpenResponses streaming event ordering",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "robot3": "^1.2.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.9.3",
+    "@types/bun": "^1.3.0"
+  }
+}

--- a/state-machines/typescript/src/buffer.ts
+++ b/state-machines/typescript/src/buffer.ts
@@ -1,0 +1,25 @@
+import type { StreamingEvent } from "./types.ts";
+
+export interface BufferAdapter {
+  enqueue(event: StreamingEvent): Promise<void>;
+  drainAll(): Promise<StreamingEvent[]>;
+  requeueAll(events: StreamingEvent[]): Promise<void>;
+}
+
+export class InMemoryBufferAdapter implements BufferAdapter {
+  private queue: StreamingEvent[] = [];
+
+  async enqueue(event: StreamingEvent): Promise<void> {
+    this.queue.push(event);
+  }
+
+  async drainAll(): Promise<StreamingEvent[]> {
+    const q = [...this.queue];
+    this.queue = [];
+    return q;
+  }
+
+  async requeueAll(events: StreamingEvent[]): Promise<void> {
+    this.queue = [...events, ...this.queue];
+  }
+}

--- a/state-machines/typescript/src/index.ts
+++ b/state-machines/typescript/src/index.ts
@@ -1,0 +1,13 @@
+export type {
+  StreamingEvent,
+  Violation,
+  ValidationResult,
+  ViolationRule,
+} from "./types.ts";
+export { ResponseStreamValidator } from "./validator.ts";
+export type { BufferAdapter } from "./buffer.ts";
+export { InMemoryBufferAdapter } from "./buffer.ts";
+export {
+  createResponseStream,
+  createResponseTransformStream,
+} from "./stream-processor.ts";

--- a/state-machines/typescript/src/machines.ts
+++ b/state-machines/typescript/src/machines.ts
@@ -1,0 +1,149 @@
+import {
+  createMachine as _createMachine,
+  state as _state,
+  transition as _transition,
+  guard as _guard,
+  interpret,
+  type Machine,
+  type Service,
+  type Transition,
+} from "robot3";
+
+// robot3's TypeScript types are overly narrow when mixing multiple event names
+// in a single state definition. These thin wrappers relax the generic constraint.
+function state(...args: Transition<string>[]): ReturnType<typeof _state> {
+  return _state(...(args as Parameters<typeof _state>));
+}
+function transition(
+  event: string,
+  target: string,
+  ...guards: ReturnType<typeof _guard>[]
+): Transition<string> {
+  return _transition(event, target, ...guards) as Transition<string>;
+}
+function guard(fn: (ctx: unknown, ev: unknown) => boolean) {
+  return _guard(fn);
+}
+function createMachine(
+  states: Record<string, ReturnType<typeof _state>>,
+): Machine {
+  return _createMachine(
+    states as Parameters<typeof _createMachine>[0],
+  ) as Machine;
+}
+
+// A tracked service wraps a robot3 service and exposes whether the last send
+// caused a state transition. This lets callers detect when robot3 silently
+// ignored an unrecognised event (no transition = invalid).
+export interface TrackedService {
+  readonly current: string;
+  readonly isTerminal: boolean;
+  // Returns true if the event caused a state transition, false if rejected.
+  send(event: { type: string }): boolean;
+}
+
+function createTrackedService(machine: Machine): TrackedService {
+  // robot3's interpret requires an onChange callback; we use a no-op.
+  const service: Service<Machine> = interpret(machine, () => {});
+
+  return {
+    get current(): string {
+      return service.machine.current as string;
+    },
+    get isTerminal(): boolean {
+      return service.machine.state.value.final;
+    },
+    send(event: { type: string }): boolean {
+      const before = service.machine.current;
+      // robot3 uses event.type to look up the transition; cast is safe here.
+      service.send(event as Parameters<typeof service.send>[0]);
+      return service.machine.current !== before;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Response FSM
+//
+// idle → created → queued → in_progress → completed | failed | incomplete
+//
+// Key rules:
+//  - response.failed can appear from idle (immediate failure)
+//  - response.completed / response.incomplete require prior in_progress
+//  - in_progress cannot loop back to in_progress
+// ---------------------------------------------------------------------------
+const responseMachineDef = createMachine({
+  idle: state(
+    transition("response.created", "created"),
+    transition("response.queued", "queued"),
+    transition("response.in_progress", "in_progress"),
+    transition("response.failed", "failed"),
+  ),
+  created: state(
+    transition("response.queued", "queued"),
+    transition("response.in_progress", "in_progress"),
+  ),
+  queued: state(transition("response.in_progress", "in_progress")),
+  in_progress: state(
+    transition("response.completed", "completed"),
+    transition("response.failed", "failed"),
+    transition("response.incomplete", "incomplete"),
+  ),
+  // Terminal states — no transitions, so final: true is set by robot3
+  completed: state(),
+  failed: state(),
+  incomplete: state(),
+});
+
+export function createResponseService(): TrackedService {
+  return createTrackedService(responseMachineDef);
+}
+
+// ---------------------------------------------------------------------------
+// Item FSM (one instance per item.id)
+//
+// idle → active → completed | incomplete
+// ---------------------------------------------------------------------------
+const itemMachineDef = createMachine({
+  idle: state(transition("response.output_item.added", "active")),
+  active: state(
+    // Guard on item.status to route to the correct terminal state
+    transition(
+      "response.output_item.done",
+      "completed",
+      guard(
+        (_ctx: unknown, ev: unknown) =>
+          (ev as { item?: { status?: string } }).item?.status !== "incomplete",
+      ),
+    ),
+    transition(
+      "response.output_item.done",
+      "incomplete",
+      guard(
+        (_ctx: unknown, ev: unknown) =>
+          (ev as { item?: { status?: string } }).item?.status === "incomplete",
+      ),
+    ),
+  ),
+  completed: state(),
+  incomplete: state(),
+});
+
+export function createItemService(): TrackedService {
+  return createTrackedService(itemMachineDef);
+}
+
+// ---------------------------------------------------------------------------
+// Content-Part FSM (one instance per `${item_id}:${content_index}`)
+//
+// idle → active → completed
+// ---------------------------------------------------------------------------
+const contentPartMachineDef = createMachine({
+  idle: state(transition("response.content_part.added", "active")),
+  active: state(transition("response.content_part.done", "completed")),
+  completed: state(),
+});
+
+export function createContentPartService(): TrackedService {
+  return createTrackedService(contentPartMachineDef);
+}

--- a/state-machines/typescript/src/router.ts
+++ b/state-machines/typescript/src/router.ts
@@ -1,0 +1,277 @@
+import type { StreamingEvent, Violation, ViolationRule } from "./types.ts";
+import {
+  createResponseService,
+  createItemService,
+  createContentPartService,
+  type TrackedService,
+} from "./machines.ts";
+
+// Event types that carry item_id + content_index (content-part deltas/dones)
+const CONTENT_PART_DELTA_TYPES = new Set([
+  "response.output_text.delta",
+  "response.output_text.done",
+  "response.output_text.annotation.added",
+  "response.refusal.delta",
+  "response.refusal.done",
+  "response.reasoning.delta",
+  "response.reasoning.done",
+  "response.reasoning_summary_part.added",
+  "response.reasoning_summary_part.done",
+  "response.reasoning_summary.delta",
+  "response.reasoning_summary.done",
+]);
+
+// Event types that carry item_id but NO content_index (item-level deltas/dones)
+const ITEM_DELTA_TYPES = new Set([
+  "response.function_call_arguments.delta",
+  "response.function_call_arguments.done",
+]);
+
+// Holds the live machines for a single streaming response.
+export class EventRouter {
+  readonly responseService: TrackedService = createResponseService();
+  readonly itemServices: Map<string, TrackedService> = new Map();
+  readonly contentPartServices: Map<string, TrackedService> = new Map();
+
+  route(event: StreamingEvent): Violation[] {
+    const violations: Violation[] = [];
+    const { type } = event;
+
+    const makeViolation = (
+      rule: ViolationRule,
+      currentState: string,
+      message: string,
+    ): Violation => ({ rule, event, currentState, message });
+
+    // -----------------------------------------------------------------------
+    // Response lifecycle
+    // -----------------------------------------------------------------------
+    if (
+      type === "response.created" ||
+      type === "response.queued" ||
+      type === "response.in_progress" ||
+      type === "response.completed" ||
+      type === "response.failed" ||
+      type === "response.incomplete"
+    ) {
+      const currentState = this.responseService.current;
+      const ok = this.responseService.send(event);
+      if (!ok) {
+        violations.push(
+          makeViolation(
+            "INVALID_RESPONSE_TRANSITION",
+            currentState,
+            `Event '${type}' is not valid in response state '${currentState}'`,
+          ),
+        );
+      }
+      return violations;
+    }
+
+    // -----------------------------------------------------------------------
+    // Item added
+    // -----------------------------------------------------------------------
+    if (type === "response.output_item.added") {
+      const itemId = event.item?.id;
+      if (!itemId) return violations;
+
+      if (this.itemServices.has(itemId)) {
+        violations.push(
+          makeViolation(
+            "DUPLICATE_ITEM",
+            this.itemServices.get(itemId)!.current,
+            `Item '${itemId}' was already added`,
+          ),
+        );
+        return violations;
+      }
+
+      const svc = createItemService();
+      this.itemServices.set(itemId, svc);
+      svc.send(event);
+      return violations;
+    }
+
+    // -----------------------------------------------------------------------
+    // Item done
+    // -----------------------------------------------------------------------
+    if (type === "response.output_item.done") {
+      const itemId = event.item?.id;
+      if (!itemId) return violations;
+
+      const svc = this.itemServices.get(itemId);
+      if (!svc) {
+        violations.push(
+          makeViolation(
+            "UNKNOWN_ITEM",
+            "—",
+            `output_item.done for unknown item '${itemId}'`,
+          ),
+        );
+        return violations;
+      }
+
+      const currentState = svc.current;
+      const ok = svc.send(event);
+      if (!ok) {
+        violations.push(
+          makeViolation(
+            "INVALID_ITEM_TRANSITION",
+            currentState,
+            `Event '${type}' is not valid in item state '${currentState}' for item '${itemId}'`,
+          ),
+        );
+      }
+      return violations;
+    }
+
+    // -----------------------------------------------------------------------
+    // Content part added
+    // -----------------------------------------------------------------------
+    if (type === "response.content_part.added") {
+      const { item_id, content_index } = event;
+      const key = `${item_id}:${content_index}`;
+
+      if (!this.itemServices.has(item_id)) {
+        violations.push(
+          makeViolation(
+            "UNKNOWN_ITEM",
+            "—",
+            `content_part.added references unknown item '${item_id}'`,
+          ),
+        );
+        return violations;
+      }
+
+      if (this.contentPartServices.has(key)) {
+        violations.push(
+          makeViolation(
+            "DUPLICATE_CONTENT_PART",
+            this.contentPartServices.get(key)!.current,
+            `Content part '${key}' was already added`,
+          ),
+        );
+        return violations;
+      }
+
+      const svc = createContentPartService();
+      this.contentPartServices.set(key, svc);
+      svc.send(event);
+      return violations;
+    }
+
+    // -----------------------------------------------------------------------
+    // Content part done
+    // -----------------------------------------------------------------------
+    if (type === "response.content_part.done") {
+      const { item_id, content_index } = event;
+      const key = `${item_id}:${content_index}`;
+
+      const svc = this.contentPartServices.get(key);
+      if (!svc) {
+        violations.push(
+          makeViolation(
+            "UNKNOWN_CONTENT_PART",
+            "—",
+            `content_part.done for unknown content part '${key}'`,
+          ),
+        );
+        return violations;
+      }
+
+      const currentState = svc.current;
+      const ok = svc.send(event);
+      if (!ok) {
+        violations.push(
+          makeViolation(
+            "INVALID_CONTENT_PART_TRANSITION",
+            currentState,
+            `Event '${type}' is not valid in content-part state '${currentState}' for '${key}'`,
+          ),
+        );
+      }
+      return violations;
+    }
+
+    // -----------------------------------------------------------------------
+    // Content-part delta/done events (carry item_id + content_index)
+    // -----------------------------------------------------------------------
+    if (CONTENT_PART_DELTA_TYPES.has(type)) {
+      const deltaEvent = event as {
+        type: string;
+        item_id: string;
+        content_index: number;
+      };
+      const { item_id, content_index } = deltaEvent;
+      const key = `${item_id}:${content_index}`;
+
+      if (!this.itemServices.has(item_id)) {
+        violations.push(
+          makeViolation(
+            "UNKNOWN_ITEM",
+            "—",
+            `Event '${type}' references unknown item '${item_id}'`,
+          ),
+        );
+        return violations;
+      }
+
+      const cpSvc = this.contentPartServices.get(key);
+      if (!cpSvc) {
+        violations.push(
+          makeViolation(
+            "UNKNOWN_CONTENT_PART",
+            "—",
+            `Event '${type}' references unknown content part '${key}'`,
+          ),
+        );
+        return violations;
+      }
+
+      if (cpSvc.isTerminal) {
+        violations.push(
+          makeViolation(
+            "INVALID_CONTENT_PART_TRANSITION",
+            cpSvc.current,
+            `Event '${type}' arrived after content part '${key}' was already done`,
+          ),
+        );
+      }
+      return violations;
+    }
+
+    // -----------------------------------------------------------------------
+    // Item-level delta/done events (carry item_id, no content_index)
+    // -----------------------------------------------------------------------
+    if (ITEM_DELTA_TYPES.has(type)) {
+      const deltaEvent = event as { type: string; item_id: string };
+      const { item_id } = deltaEvent;
+
+      const itemSvc = this.itemServices.get(item_id);
+      if (!itemSvc) {
+        violations.push(
+          makeViolation(
+            "UNKNOWN_ITEM",
+            "—",
+            `Event '${type}' references unknown item '${item_id}'`,
+          ),
+        );
+        return violations;
+      }
+
+      if (itemSvc.isTerminal) {
+        violations.push(
+          makeViolation(
+            "INVALID_ITEM_TRANSITION",
+            itemSvc.current,
+            `Event '${type}' arrived after item '${item_id}' was already done`,
+          ),
+        );
+      }
+      return violations;
+    }
+
+    // error events and anything else are pass-through
+    return violations;
+  }
+}

--- a/state-machines/typescript/src/stream-processor.test.ts
+++ b/state-machines/typescript/src/stream-processor.test.ts
@@ -1,0 +1,421 @@
+import { describe, it, expect } from "bun:test";
+import { createResponseStream } from "./stream-processor.ts";
+import { InMemoryBufferAdapter } from "./buffer.ts";
+import type { BufferAdapter } from "./buffer.ts";
+import type { StreamingEvent } from "./types.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function* fromArray(
+  arr: StreamingEvent[],
+): AsyncGenerator<StreamingEvent> {
+  for (const item of arr) {
+    yield item;
+  }
+}
+
+async function toArray(
+  gen: AsyncIterable<StreamingEvent>,
+): Promise<StreamingEvent[]> {
+  const result: StreamingEvent[] = [];
+  for await (const item of gen) {
+    result.push(item);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("createResponseStream", () => {
+  describe("no buffer (pass-through)", () => {
+    it("emits events unchanged when no buffer is provided", async () => {
+      const events: StreamingEvent[] = [
+        { type: "response.created", sequence_number: 1 },
+        { type: "response.in_progress", sequence_number: 2 },
+        { type: "response.completed", sequence_number: 3 },
+      ];
+
+      const output = await toArray(createResponseStream(fromArray(events)));
+      expect(output).toEqual(events);
+    });
+
+    it("passes out-of-order events through unchanged with no buffer", async () => {
+      const events: StreamingEvent[] = [
+        { type: "response.created", sequence_number: 1 },
+        {
+          type: "response.function_call_arguments.delta",
+          item_id: "item-1",
+          output_index: 0,
+          sequence_number: 2,
+        },
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { id: "item-1" },
+          sequence_number: 3,
+        },
+        { type: "response.completed", sequence_number: 4 },
+      ];
+
+      const output = await toArray(createResponseStream(fromArray(events)));
+      // No reordering — events come out exactly as they went in
+      expect(output.map((e) => e.type)).toEqual([
+        "response.created",
+        "response.function_call_arguments.delta",
+        "response.output_item.added",
+        "response.completed",
+      ]);
+    });
+  });
+
+  describe("output_item.added arrives late", () => {
+    it("buffers delta events until output_item.added is seen", async () => {
+      const events: StreamingEvent[] = [
+        { type: "response.created", sequence_number: 1 },
+        { type: "response.in_progress", sequence_number: 2 },
+        // Delta arrives before item is opened
+        {
+          type: "response.function_call_arguments.delta",
+          item_id: "item-1",
+          output_index: 0,
+          sequence_number: 3,
+        },
+        {
+          type: "response.function_call_arguments.done",
+          item_id: "item-1",
+          output_index: 0,
+          sequence_number: 4,
+        },
+        // Gateway event
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { id: "item-1" },
+          sequence_number: 5,
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          item: { id: "item-1", status: "completed" },
+          sequence_number: 6,
+        },
+        { type: "response.completed", sequence_number: 7 },
+      ];
+
+      const output = await toArray(
+        createResponseStream(fromArray(events), {
+          buffer: new InMemoryBufferAdapter(),
+        }),
+      );
+      const types = output.map((e) => e.type);
+
+      const addedIdx = types.indexOf("response.output_item.added");
+      const deltaIdx = types.indexOf("response.function_call_arguments.delta");
+      const doneIdx = types.indexOf("response.function_call_arguments.done");
+
+      expect(addedIdx).toBeGreaterThanOrEqual(0);
+      expect(addedIdx).toBeLessThan(deltaIdx);
+      expect(addedIdx).toBeLessThan(doneIdx);
+      expect(output).toHaveLength(7);
+    });
+  });
+
+  describe("content_part.added arrives late", () => {
+    it("buffers content delta events until content_part.added is seen", async () => {
+      const events: StreamingEvent[] = [
+        { type: "response.created", sequence_number: 1 },
+        { type: "response.in_progress", sequence_number: 2 },
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { id: "item-1" },
+          sequence_number: 3,
+        },
+        // Content delta arrives before content_part.added
+        {
+          type: "response.output_text.delta",
+          item_id: "item-1",
+          output_index: 0,
+          content_index: 0,
+          sequence_number: 4,
+        },
+        // Gateway for content part
+        {
+          type: "response.content_part.added",
+          item_id: "item-1",
+          output_index: 0,
+          content_index: 0,
+          sequence_number: 5,
+        },
+        {
+          type: "response.output_text.done",
+          item_id: "item-1",
+          output_index: 0,
+          content_index: 0,
+          sequence_number: 6,
+        },
+        {
+          type: "response.content_part.done",
+          item_id: "item-1",
+          output_index: 0,
+          content_index: 0,
+          sequence_number: 7,
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          item: { id: "item-1", status: "completed" },
+          sequence_number: 8,
+        },
+        { type: "response.completed", sequence_number: 9 },
+      ];
+
+      const output = await toArray(
+        createResponseStream(fromArray(events), {
+          buffer: new InMemoryBufferAdapter(),
+        }),
+      );
+      const types = output.map((e) => e.type);
+
+      const cpAddedIdx = types.indexOf("response.content_part.added");
+      const textDeltaIdx = types.indexOf("response.output_text.delta");
+
+      expect(cpAddedIdx).toBeGreaterThanOrEqual(0);
+      expect(cpAddedIdx).toBeLessThan(textDeltaIdx);
+      expect(output).toHaveLength(9);
+    });
+  });
+
+  describe("transitive unlock", () => {
+    it("unlocks content_part.added via item gate, then content deltas via content gate", async () => {
+      const events: StreamingEvent[] = [
+        { type: "response.created", sequence_number: 1 },
+        { type: "response.in_progress", sequence_number: 2 },
+        // Content delta arrives first — needs both item and content part
+        {
+          type: "response.output_text.delta",
+          item_id: "item-1",
+          output_index: 0,
+          content_index: 0,
+          sequence_number: 3,
+        },
+        // Content part added arrives next — needs item
+        {
+          type: "response.content_part.added",
+          item_id: "item-1",
+          output_index: 0,
+          content_index: 0,
+          sequence_number: 4,
+        },
+        // Item added arrives last — gateway that unlocks everything
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { id: "item-1" },
+          sequence_number: 5,
+        },
+        {
+          type: "response.content_part.done",
+          item_id: "item-1",
+          output_index: 0,
+          content_index: 0,
+          sequence_number: 6,
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          item: { id: "item-1", status: "completed" },
+          sequence_number: 7,
+        },
+        { type: "response.completed", sequence_number: 8 },
+      ];
+
+      const output = await toArray(
+        createResponseStream(fromArray(events), {
+          buffer: new InMemoryBufferAdapter(),
+        }),
+      );
+      const types = output.map((e) => e.type);
+
+      const itemAddedIdx = types.indexOf("response.output_item.added");
+      const cpAddedIdx = types.indexOf("response.content_part.added");
+      const textDeltaIdx = types.indexOf("response.output_text.delta");
+
+      expect(itemAddedIdx).toBeLessThan(cpAddedIdx);
+      expect(cpAddedIdx).toBeLessThan(textDeltaIdx);
+      expect(output).toHaveLength(8);
+    });
+  });
+
+  describe("multiple items interleaved", () => {
+    it("flushes each item's buffered events independently when their gateway arrives", async () => {
+      const events: StreamingEvent[] = [
+        { type: "response.created", sequence_number: 1 },
+        { type: "response.in_progress", sequence_number: 2 },
+        // item-2 delta arrives before item-2 is opened
+        {
+          type: "response.function_call_arguments.delta",
+          item_id: "item-2",
+          output_index: 1,
+          sequence_number: 3,
+        },
+        // item-1 opens (does not unlock item-2's delta)
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { id: "item-1" },
+          sequence_number: 4,
+        },
+        {
+          type: "response.function_call_arguments.delta",
+          item_id: "item-1",
+          output_index: 0,
+          sequence_number: 5,
+        },
+        // item-2 opens (should flush item-2's buffered delta)
+        {
+          type: "response.output_item.added",
+          output_index: 1,
+          item: { id: "item-2" },
+          sequence_number: 6,
+        },
+        {
+          type: "response.function_call_arguments.done",
+          item_id: "item-1",
+          output_index: 0,
+          sequence_number: 7,
+        },
+        {
+          type: "response.function_call_arguments.done",
+          item_id: "item-2",
+          output_index: 1,
+          sequence_number: 8,
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          item: { id: "item-1", status: "completed" },
+          sequence_number: 9,
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 1,
+          item: { id: "item-2", status: "completed" },
+          sequence_number: 10,
+        },
+        { type: "response.completed", sequence_number: 11 },
+      ];
+
+      const output = await toArray(
+        createResponseStream(fromArray(events), {
+          buffer: new InMemoryBufferAdapter(),
+        }),
+      );
+
+      const item2AddedIdx = output.findIndex(
+        (e) =>
+          e.type === "response.output_item.added" &&
+          (e as { item?: { id: string } }).item?.id === "item-2",
+      );
+      const item2DeltaIdx = output.findIndex(
+        (e) =>
+          e.type === "response.function_call_arguments.delta" &&
+          (e as { item_id?: string }).item_id === "item-2",
+      );
+
+      expect(item2AddedIdx).toBeGreaterThanOrEqual(0);
+      expect(item2DeltaIdx).toBeGreaterThan(item2AddedIdx);
+      expect(output).toHaveLength(11);
+    });
+  });
+
+  describe("events in buffer at end of stream (unreachable gateway)", () => {
+    it("drains remaining buffered events when the stream ends without their gateway", async () => {
+      const events: StreamingEvent[] = [
+        { type: "response.created", sequence_number: 1 },
+        { type: "response.in_progress", sequence_number: 2 },
+        // Delta for an item that is never opened
+        {
+          type: "response.function_call_arguments.delta",
+          item_id: "item-ghost",
+          output_index: 0,
+          sequence_number: 3,
+        },
+        { type: "response.completed", sequence_number: 4 },
+      ];
+
+      const output = await toArray(
+        createResponseStream(fromArray(events), {
+          buffer: new InMemoryBufferAdapter(),
+        }),
+      );
+
+      expect(output).toHaveLength(4);
+      expect(output[3]!.type).toBe("response.function_call_arguments.delta");
+    });
+  });
+
+  describe("custom adapter", () => {
+    it("calls enqueue, drainAll, and requeueAll on the adapter", async () => {
+      const enqueuedEvents: StreamingEvent[] = [];
+      const drainAllCallCount = { count: 0 };
+      const requeuedBatches: StreamingEvent[][] = [];
+
+      const spyAdapter: BufferAdapter = {
+        async enqueue(event) {
+          enqueuedEvents.push(event);
+        },
+        async drainAll() {
+          drainAllCallCount.count++;
+          const snapshot = [...enqueuedEvents];
+          enqueuedEvents.length = 0;
+          return snapshot;
+        },
+        async requeueAll(events) {
+          requeuedBatches.push(events);
+          enqueuedEvents.unshift(...events);
+        },
+      };
+
+      const events: StreamingEvent[] = [
+        { type: "response.created", sequence_number: 1 },
+        { type: "response.in_progress", sequence_number: 2 },
+        // Delta arrives before item — must be buffered
+        {
+          type: "response.function_call_arguments.delta",
+          item_id: "item-1",
+          output_index: 0,
+          sequence_number: 3,
+        },
+        // Gateway arrives and should flush the buffered delta
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { id: "item-1" },
+          sequence_number: 4,
+        },
+        { type: "response.completed", sequence_number: 5 },
+      ];
+
+      const output = await toArray(
+        createResponseStream(fromArray(events), { buffer: spyAdapter }),
+      );
+
+      // The delta was buffered
+      expect(drainAllCallCount.count).toBeGreaterThan(0);
+
+      // All 5 events should appear in the output
+      expect(output).toHaveLength(5);
+
+      // output_item.added must appear before the delta
+      const types = output.map((e) => e.type);
+      const addedIdx = types.indexOf("response.output_item.added");
+      const deltaIdx = types.indexOf("response.function_call_arguments.delta");
+      expect(addedIdx).toBeLessThan(deltaIdx);
+    });
+  });
+});

--- a/state-machines/typescript/src/stream-processor.ts
+++ b/state-machines/typescript/src/stream-processor.ts
@@ -1,0 +1,232 @@
+import type { StreamingEvent } from "./types.ts";
+import type { BufferAdapter } from "./buffer.ts";
+
+// Events that carry item_id + content_index (content-part deltas/dones)
+const CONTENT_PART_DELTA_TYPES = new Set([
+  "response.output_text.delta",
+  "response.output_text.done",
+  "response.output_text.annotation.added",
+  "response.refusal.delta",
+  "response.refusal.done",
+  "response.reasoning.delta",
+  "response.reasoning.done",
+  "response.reasoning_summary_part.added",
+  "response.reasoning_summary_part.done",
+  "response.reasoning_summary.delta",
+  "response.reasoning_summary.done",
+]);
+
+// Events that carry item_id but NO content_index (item-level deltas/dones)
+const ITEM_DELTA_TYPES = new Set([
+  "response.function_call_arguments.delta",
+  "response.function_call_arguments.done",
+]);
+
+/**
+ * Returns the item ID that must already be open for this event to be valid,
+ * or null if the event has no item dependency.
+ */
+function getRequiredItemId(event: StreamingEvent): string | null {
+  const { type } = event;
+  if (type === "response.output_item.done") {
+    return event.item?.id ?? null;
+  }
+  if (
+    type === "response.content_part.added" ||
+    type === "response.content_part.done" ||
+    CONTENT_PART_DELTA_TYPES.has(type) ||
+    ITEM_DELTA_TYPES.has(type)
+  ) {
+    return (event as { item_id: string }).item_id;
+  }
+  return null;
+}
+
+/**
+ * Returns the content-part key ("item_id:content_index") that must already be
+ * open for this event to be valid, or null if there is no content-part dependency.
+ */
+function getRequiredContentPartKey(event: StreamingEvent): string | null {
+  const { type } = event;
+  if (
+    type === "response.content_part.done" ||
+    CONTENT_PART_DELTA_TYPES.has(type)
+  ) {
+    const e = event as { item_id: string; content_index: number };
+    return `${e.item_id}:${e.content_index}`;
+  }
+  return null;
+}
+
+/**
+ * Processes incoming streaming events, optionally buffering premature item/
+ * content-part delta events until their gateway events have been seen.
+ *
+ * When no buffer adapter is supplied, events are emitted immediately
+ * (identical to the existing pass-through behavior).
+ *
+ * When a buffer adapter is supplied, events whose item or content-part has
+ * not yet been opened are enqueued; gateway events (`response.output_item.added`,
+ * `response.content_part.added`) trigger a drain loop that re-emits now-valid
+ * buffered events. At the end of the stream any remaining buffered events are
+ * emitted unconditionally.
+ */
+export async function* createResponseStream(
+  input: AsyncIterable<StreamingEvent>,
+  options?: { buffer?: BufferAdapter },
+): AsyncGenerator<StreamingEvent> {
+  const buffer = options?.buffer;
+
+  if (!buffer) {
+    for await (const event of input) {
+      yield event;
+    }
+    return;
+  }
+
+  // Narrow to a non-optional reference so closures below can use it safely.
+  const buf: BufferAdapter = buffer;
+
+  const openItems = new Set<string>();
+  const openContentParts = new Set<string>();
+
+  function isReady(event: StreamingEvent): boolean {
+    const itemId = getRequiredItemId(event);
+    if (itemId !== null && !openItems.has(itemId)) return false;
+    const cpKey = getRequiredContentPartKey(event);
+    if (cpKey !== null && !openContentParts.has(cpKey)) return false;
+    return true;
+  }
+
+  function registerGateway(event: StreamingEvent): void {
+    if (event.type === "response.output_item.added" && event.item?.id) {
+      openItems.add(event.item.id);
+    } else if (event.type === "response.content_part.added") {
+      openContentParts.add(`${event.item_id}:${event.content_index}`);
+    }
+  }
+
+  // Repeatedly drain the buffer until no more events become ready.
+  // Returns all events that were drained and emitted.
+  async function drainLoop(): Promise<StreamingEvent[]> {
+    const result: StreamingEvent[] = [];
+    let madeProgress = true;
+    while (madeProgress) {
+      madeProgress = false;
+      const buffered = await buf.drainAll();
+      const requeue: StreamingEvent[] = [];
+      for (const event of buffered) {
+        if (isReady(event)) {
+          madeProgress = true;
+          registerGateway(event);
+          result.push(event);
+        } else {
+          requeue.push(event);
+        }
+      }
+      if (requeue.length > 0) {
+        await buf.requeueAll(requeue);
+      }
+    }
+    return result;
+  }
+
+  for await (const event of input) {
+    if (isReady(event)) {
+      registerGateway(event);
+      yield event;
+      // Gateway events may unlock buffered events — drain after each one.
+      if (
+        event.type === "response.output_item.added" ||
+        event.type === "response.content_part.added"
+      ) {
+        const drained = await drainLoop();
+        for (const e of drained) yield e;
+      }
+    } else {
+      await buf.enqueue(event);
+    }
+  }
+
+  // After the input stream ends, run a final drain loop for any events that
+  // were unlocked by late-arriving gateways.
+  const finalDrained = await drainLoop();
+  for (const e of finalDrained) yield e;
+
+  // Emit any events that remain in the buffer and could never be unlocked
+  // (e.g. their gateway event was missing from the stream entirely).
+  const remaining = await buf.drainAll();
+  for (const e of remaining) yield e;
+}
+
+/**
+ * Returns a TransformStream that reorders streaming events into a valid FSM
+ * sequence using the provided buffer adapter.
+ *
+ * When no buffer is provided, events pass through unchanged.
+ */
+export function createResponseTransformStream(options?: {
+  buffer?: BufferAdapter;
+}): TransformStream<StreamingEvent, StreamingEvent> {
+  const queue: StreamingEvent[] = [];
+  let resume: (() => void) | null = null;
+  let inputDone = false;
+
+  async function* makeInput(): AsyncGenerator<StreamingEvent> {
+    while (true) {
+      if (queue.length > 0) {
+        yield queue.shift()!;
+      } else if (inputDone) {
+        return;
+      } else {
+        await new Promise<void>((r) => {
+          resume = r;
+        });
+      }
+    }
+  }
+
+  let controller!: ReadableStreamDefaultController<StreamingEvent>;
+
+  const readable = new ReadableStream<StreamingEvent>({
+    start(c) {
+      controller = c;
+      (async () => {
+        for await (const event of createResponseStream(makeInput(), options)) {
+          controller.enqueue(event);
+        }
+        controller.close();
+      })().catch((err) => controller.error(err));
+    },
+  });
+
+  const writable = new WritableStream<StreamingEvent>({
+    write(chunk) {
+      queue.push(chunk);
+      if (resume) {
+        const r = resume;
+        resume = null;
+        r();
+      }
+    },
+    close() {
+      inputDone = true;
+      if (resume) {
+        const r = resume;
+        resume = null;
+        r();
+      }
+    },
+    abort(reason) {
+      inputDone = true;
+      if (resume) {
+        const r = resume;
+        resume = null;
+        r();
+      }
+      controller.error(reason);
+    },
+  });
+
+  return { readable, writable };
+}

--- a/state-machines/typescript/src/types.ts
+++ b/state-machines/typescript/src/types.ts
@@ -1,0 +1,197 @@
+// Minimal discriminated union for streaming events.
+// Only the fields the state machine needs are included.
+// Events from sse-parser.ts are assignable to these types by structural compatibility.
+
+export type ViolationRule =
+  | "INVALID_RESPONSE_TRANSITION"
+  | "INVALID_ITEM_TRANSITION"
+  | "INVALID_CONTENT_PART_TRANSITION"
+  | "NON_MONOTONIC_SEQUENCE"
+  | "UNKNOWN_ITEM"
+  | "UNKNOWN_CONTENT_PART"
+  | "DUPLICATE_ITEM"
+  | "DUPLICATE_CONTENT_PART"
+  | "RESPONSE_NOT_TERMINATED"
+  | "ITEM_NOT_TERMINATED"
+  | "CONTENT_PART_NOT_TERMINATED";
+
+export interface Violation {
+  rule: ViolationRule;
+  event: StreamingEvent;
+  currentState: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  violations: Violation[];
+}
+
+// Base event fields present on every streaming event
+interface BaseEvent {
+  type: string;
+  sequence_number: number;
+}
+
+// Response lifecycle events
+interface ResponseCreatedEvent extends BaseEvent {
+  type: "response.created";
+}
+interface ResponseQueuedEvent extends BaseEvent {
+  type: "response.queued";
+}
+interface ResponseInProgressEvent extends BaseEvent {
+  type: "response.in_progress";
+}
+interface ResponseCompletedEvent extends BaseEvent {
+  type: "response.completed";
+}
+interface ResponseFailedEvent extends BaseEvent {
+  type: "response.failed";
+}
+interface ResponseIncompleteEvent extends BaseEvent {
+  type: "response.incomplete";
+}
+
+// Item lifecycle events
+interface ResponseOutputItemAddedEvent extends BaseEvent {
+  type: "response.output_item.added";
+  output_index: number;
+  item: { id: string } | null;
+}
+interface ResponseOutputItemDoneEvent extends BaseEvent {
+  type: "response.output_item.done";
+  output_index: number;
+  item: { id: string; status?: string } | null;
+}
+
+// Content part lifecycle events
+interface ResponseContentPartAddedEvent extends BaseEvent {
+  type: "response.content_part.added";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+}
+interface ResponseContentPartDoneEvent extends BaseEvent {
+  type: "response.content_part.done";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+}
+
+// Output text events
+interface ResponseOutputTextDeltaEvent extends BaseEvent {
+  type: "response.output_text.delta";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+}
+interface ResponseOutputTextDoneEvent extends BaseEvent {
+  type: "response.output_text.done";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+}
+interface ResponseOutputTextAnnotationAddedEvent extends BaseEvent {
+  type: "response.output_text.annotation.added";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+}
+
+// Refusal events
+interface ResponseRefusalDeltaEvent extends BaseEvent {
+  type: "response.refusal.delta";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+}
+interface ResponseRefusalDoneEvent extends BaseEvent {
+  type: "response.refusal.done";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+}
+
+// Function call events (no content_index)
+interface ResponseFunctionCallArgumentsDeltaEvent extends BaseEvent {
+  type: "response.function_call_arguments.delta";
+  item_id: string;
+  output_index: number;
+}
+interface ResponseFunctionCallArgumentsDoneEvent extends BaseEvent {
+  type: "response.function_call_arguments.done";
+  item_id: string;
+  output_index: number;
+}
+
+// Reasoning events (with content_index)
+interface ResponseReasoningDeltaEvent extends BaseEvent {
+  type: "response.reasoning.delta";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+}
+interface ResponseReasoningDoneEvent extends BaseEvent {
+  type: "response.reasoning.done";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+}
+
+// Reasoning summary events (with content_index)
+interface ResponseReasoningSummaryPartAddedEvent extends BaseEvent {
+  type: "response.reasoning_summary_part.added";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+}
+interface ResponseReasoningSummaryPartDoneEvent extends BaseEvent {
+  type: "response.reasoning_summary_part.done";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+}
+interface ResponseReasoningSummaryDeltaEvent extends BaseEvent {
+  type: "response.reasoning_summary.delta";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+}
+interface ResponseReasoningSummaryDoneEvent extends BaseEvent {
+  type: "response.reasoning_summary.done";
+  item_id: string;
+  output_index: number;
+  content_index: number;
+}
+
+// Error event (pass-through, no state transition)
+interface ErrorEvent extends BaseEvent {
+  type: "error";
+}
+
+export type StreamingEvent =
+  | ResponseCreatedEvent
+  | ResponseQueuedEvent
+  | ResponseInProgressEvent
+  | ResponseCompletedEvent
+  | ResponseFailedEvent
+  | ResponseIncompleteEvent
+  | ResponseOutputItemAddedEvent
+  | ResponseOutputItemDoneEvent
+  | ResponseContentPartAddedEvent
+  | ResponseContentPartDoneEvent
+  | ResponseOutputTextDeltaEvent
+  | ResponseOutputTextDoneEvent
+  | ResponseOutputTextAnnotationAddedEvent
+  | ResponseRefusalDeltaEvent
+  | ResponseRefusalDoneEvent
+  | ResponseFunctionCallArgumentsDeltaEvent
+  | ResponseFunctionCallArgumentsDoneEvent
+  | ResponseReasoningDeltaEvent
+  | ResponseReasoningDoneEvent
+  | ResponseReasoningSummaryPartAddedEvent
+  | ResponseReasoningSummaryPartDoneEvent
+  | ResponseReasoningSummaryDeltaEvent
+  | ResponseReasoningSummaryDoneEvent
+  | ErrorEvent;

--- a/state-machines/typescript/src/validator.test.ts
+++ b/state-machines/typescript/src/validator.test.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { ResponseStreamValidator } from "./validator.ts";
+import type { StreamingEvent } from "./types.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers to build minimal valid streaming events
+// ---------------------------------------------------------------------------
+let seq = 0;
+function nextSeq() {
+  return ++seq;
+}
+
+function resetSeq() {
+  seq = 0;
+}
+
+function ev<T extends Partial<StreamingEvent> & { type: string }>(
+  fields: T,
+): T & { sequence_number: number } {
+  return { sequence_number: nextSeq(), ...fields } as T & {
+    sequence_number: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ResponseStreamValidator", () => {
+  // Reset sequence counter before each test group
+  beforeEach(() => resetSeq());
+
+  describe("happy path", () => {
+    it("passes a valid end-to-end stream with no violations", () => {
+      const v = new ResponseStreamValidator();
+
+      const results = [
+        v.send(ev({ type: "response.created" })),
+        v.send(ev({ type: "response.in_progress" })),
+        v.send(
+          ev({
+            type: "response.output_item.added",
+            output_index: 0,
+            item: { id: "item-1" },
+          }),
+        ),
+        v.send(
+          ev({
+            type: "response.content_part.added",
+            item_id: "item-1",
+            output_index: 0,
+            content_index: 0,
+          }),
+        ),
+        v.send(
+          ev({
+            type: "response.output_text.delta",
+            item_id: "item-1",
+            output_index: 0,
+            content_index: 0,
+          }),
+        ),
+        v.send(
+          ev({
+            type: "response.output_text.done",
+            item_id: "item-1",
+            output_index: 0,
+            content_index: 0,
+          }),
+        ),
+        v.send(
+          ev({
+            type: "response.content_part.done",
+            item_id: "item-1",
+            output_index: 0,
+            content_index: 0,
+          }),
+        ),
+        v.send(
+          ev({
+            type: "response.output_item.done",
+            output_index: 0,
+            item: { id: "item-1", status: "completed" },
+          }),
+        ),
+        v.send(ev({ type: "response.completed" })),
+      ];
+
+      for (const r of results) {
+        expect(r.valid).toBe(true);
+        expect(r.violations).toHaveLength(0);
+      }
+
+      const final = v.finalize();
+      expect(final.valid).toBe(true);
+      expect(final.violations).toHaveLength(0);
+    });
+  });
+
+  describe("response FSM violations", () => {
+    it("rejects response.completed before response.in_progress", () => {
+      const v = new ResponseStreamValidator();
+      v.send(ev({ type: "response.created" }));
+      const r = v.send(ev({ type: "response.completed" }));
+      expect(r.valid).toBe(false);
+      expect(r.violations[0]?.rule).toBe("INVALID_RESPONSE_TRANSITION");
+    });
+
+    it("allows response.failed as the first response event", () => {
+      const v = new ResponseStreamValidator();
+      const r = v.send(ev({ type: "response.failed" }));
+      expect(r.valid).toBe(true);
+      expect(r.violations).toHaveLength(0);
+    });
+
+    it("rejects an event after a terminal response state", () => {
+      const v = new ResponseStreamValidator();
+      v.send(ev({ type: "response.in_progress" }));
+      v.send(ev({ type: "response.completed" }));
+      const r = v.send(ev({ type: "response.completed" }));
+      expect(r.valid).toBe(false);
+      expect(r.violations[0]?.rule).toBe("INVALID_RESPONSE_TRANSITION");
+    });
+  });
+
+  describe("item FSM violations", () => {
+    it("rejects a delta event before output_item.added (UNKNOWN_ITEM)", () => {
+      const v = new ResponseStreamValidator();
+      v.send(ev({ type: "response.in_progress" }));
+      const r = v.send(
+        ev({
+          type: "response.function_call_arguments.delta",
+          item_id: "missing-item",
+          output_index: 0,
+        }),
+      );
+      expect(r.valid).toBe(false);
+      expect(r.violations[0]?.rule).toBe("UNKNOWN_ITEM");
+    });
+
+    it("rejects a duplicate output_item.added (DUPLICATE_ITEM)", () => {
+      const v = new ResponseStreamValidator();
+      v.send(ev({ type: "response.in_progress" }));
+      v.send(
+        ev({
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { id: "item-1" },
+        }),
+      );
+      const r = v.send(
+        ev({
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { id: "item-1" },
+        }),
+      );
+      expect(r.valid).toBe(false);
+      expect(r.violations[0]?.rule).toBe("DUPLICATE_ITEM");
+    });
+
+    it("rejects output_item.done for an unknown item", () => {
+      const v = new ResponseStreamValidator();
+      v.send(ev({ type: "response.in_progress" }));
+      const r = v.send(
+        ev({
+          type: "response.output_item.done",
+          output_index: 0,
+          item: { id: "ghost-item", status: "completed" },
+        }),
+      );
+      expect(r.valid).toBe(false);
+      expect(r.violations[0]?.rule).toBe("UNKNOWN_ITEM");
+    });
+  });
+
+  describe("content-part FSM violations", () => {
+    it("rejects a delta before content_part.added (UNKNOWN_CONTENT_PART)", () => {
+      const v = new ResponseStreamValidator();
+      v.send(ev({ type: "response.in_progress" }));
+      v.send(
+        ev({
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { id: "item-1" },
+        }),
+      );
+      const r = v.send(
+        ev({
+          type: "response.output_text.delta",
+          item_id: "item-1",
+          output_index: 0,
+          content_index: 0,
+        }),
+      );
+      expect(r.valid).toBe(false);
+      expect(r.violations[0]?.rule).toBe("UNKNOWN_CONTENT_PART");
+    });
+
+    it("rejects a delta after content_part.done", () => {
+      const v = new ResponseStreamValidator();
+      v.send(ev({ type: "response.in_progress" }));
+      v.send(
+        ev({
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { id: "item-1" },
+        }),
+      );
+      v.send(
+        ev({
+          type: "response.content_part.added",
+          item_id: "item-1",
+          output_index: 0,
+          content_index: 0,
+        }),
+      );
+      v.send(
+        ev({
+          type: "response.content_part.done",
+          item_id: "item-1",
+          output_index: 0,
+          content_index: 0,
+        }),
+      );
+      const r = v.send(
+        ev({
+          type: "response.output_text.delta",
+          item_id: "item-1",
+          output_index: 0,
+          content_index: 0,
+        }),
+      );
+      expect(r.valid).toBe(false);
+      expect(r.violations[0]?.rule).toBe("INVALID_CONTENT_PART_TRANSITION");
+    });
+
+    it("rejects a duplicate content_part.added (DUPLICATE_CONTENT_PART)", () => {
+      const v = new ResponseStreamValidator();
+      v.send(ev({ type: "response.in_progress" }));
+      v.send(
+        ev({
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { id: "item-1" },
+        }),
+      );
+      v.send(
+        ev({
+          type: "response.content_part.added",
+          item_id: "item-1",
+          output_index: 0,
+          content_index: 0,
+        }),
+      );
+      const r = v.send(
+        ev({
+          type: "response.content_part.added",
+          item_id: "item-1",
+          output_index: 0,
+          content_index: 0,
+        }),
+      );
+      expect(r.valid).toBe(false);
+      expect(r.violations[0]?.rule).toBe("DUPLICATE_CONTENT_PART");
+    });
+  });
+
+  describe("sequence number validation", () => {
+    it("rejects a non-monotonic sequence number (NON_MONOTONIC_SEQUENCE)", () => {
+      const v = new ResponseStreamValidator();
+      // Use explicit sequence numbers to control order
+      v.send({
+        type: "response.created",
+        sequence_number: 1,
+      } as StreamingEvent);
+      v.send({
+        type: "response.in_progress",
+        sequence_number: 5,
+      } as StreamingEvent);
+      const r = v.send({
+        type: "response.completed",
+        sequence_number: 3,
+      } as StreamingEvent);
+      expect(r.valid).toBe(false);
+      expect(r.violations[0]?.rule).toBe("NON_MONOTONIC_SEQUENCE");
+    });
+
+    it("rejects an equal sequence number (NON_MONOTONIC_SEQUENCE)", () => {
+      const v = new ResponseStreamValidator();
+      v.send({
+        type: "response.created",
+        sequence_number: 1,
+      } as StreamingEvent);
+      const r = v.send({
+        type: "response.in_progress",
+        sequence_number: 1,
+      } as StreamingEvent);
+      expect(r.valid).toBe(false);
+      expect(r.violations[0]?.rule).toBe("NON_MONOTONIC_SEQUENCE");
+    });
+  });
+
+  describe("finalize() checks", () => {
+    it("reports RESPONSE_NOT_TERMINATED when stream ends without a terminal event", () => {
+      const v = new ResponseStreamValidator();
+      v.send(ev({ type: "response.in_progress" }));
+      const final = v.finalize();
+      expect(final.valid).toBe(false);
+      expect(
+        final.violations.some((v) => v.rule === "RESPONSE_NOT_TERMINATED"),
+      ).toBe(true);
+    });
+
+    it("reports ITEM_NOT_TERMINATED when an item is never closed", () => {
+      const v = new ResponseStreamValidator();
+      v.send(ev({ type: "response.in_progress" }));
+      v.send(
+        ev({
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { id: "item-1" },
+        }),
+      );
+      v.send(ev({ type: "response.completed" }));
+      const final = v.finalize();
+      expect(final.valid).toBe(false);
+      expect(
+        final.violations.some((v) => v.rule === "ITEM_NOT_TERMINATED"),
+      ).toBe(true);
+    });
+
+    it("reports CONTENT_PART_NOT_TERMINATED when a content part is never closed", () => {
+      const v = new ResponseStreamValidator();
+      v.send(ev({ type: "response.in_progress" }));
+      v.send(
+        ev({
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { id: "item-1" },
+        }),
+      );
+      v.send(
+        ev({
+          type: "response.content_part.added",
+          item_id: "item-1",
+          output_index: 0,
+          content_index: 0,
+        }),
+      );
+      v.send(
+        ev({
+          type: "response.output_item.done",
+          output_index: 0,
+          item: { id: "item-1", status: "completed" },
+        }),
+      );
+      v.send(ev({ type: "response.completed" }));
+      const final = v.finalize();
+      expect(final.valid).toBe(false);
+      expect(
+        final.violations.some((v) => v.rule === "CONTENT_PART_NOT_TERMINATED"),
+      ).toBe(true);
+    });
+
+    it("returns valid:true for a well-terminated stream", () => {
+      const v = new ResponseStreamValidator();
+      v.send(ev({ type: "response.in_progress" }));
+      v.send(
+        ev({
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { id: "item-1" },
+        }),
+      );
+      v.send(
+        ev({
+          type: "response.content_part.added",
+          item_id: "item-1",
+          output_index: 0,
+          content_index: 0,
+        }),
+      );
+      v.send(
+        ev({
+          type: "response.content_part.done",
+          item_id: "item-1",
+          output_index: 0,
+          content_index: 0,
+        }),
+      );
+      v.send(
+        ev({
+          type: "response.output_item.done",
+          output_index: 0,
+          item: { id: "item-1", status: "completed" },
+        }),
+      );
+      v.send(ev({ type: "response.completed" }));
+      const final = v.finalize();
+      expect(final.valid).toBe(true);
+    });
+  });
+});

--- a/state-machines/typescript/src/validator.ts
+++ b/state-machines/typescript/src/validator.ts
@@ -1,0 +1,87 @@
+import type { StreamingEvent, ValidationResult, Violation } from "./types.ts";
+import { EventRouter } from "./router.ts";
+
+export class ResponseStreamValidator {
+  private router = new EventRouter();
+  private lastSequenceNumber = -1;
+  private allViolations: Violation[] = [];
+
+  /**
+   * Feed a single streaming event into the validator.
+   * Returns the violations detected for this specific event.
+   */
+  send(event: StreamingEvent): ValidationResult {
+    const violations: Violation[] = [];
+
+    // Sequence number must be strictly increasing
+    if (event.sequence_number <= this.lastSequenceNumber) {
+      violations.push({
+        rule: "NON_MONOTONIC_SEQUENCE",
+        event,
+        currentState: this.router.responseService.current,
+        message: `sequence_number ${event.sequence_number} is not greater than previous ${this.lastSequenceNumber}`,
+      });
+    }
+    this.lastSequenceNumber = event.sequence_number;
+
+    // Route the event through the state machines
+    const routeViolations = this.router.route(event);
+    violations.push(...routeViolations);
+
+    this.allViolations.push(...violations);
+    return { valid: violations.length === 0, violations };
+  }
+
+  /**
+   * Call after the stream ends to check that all machines reached terminal states.
+   */
+  finalize(): ValidationResult {
+    const violations: Violation[] = [];
+
+    // Synthesise a sentinel event for finalize violations (no real event)
+    const sentinel = {
+      type: "__finalize__",
+      sequence_number: this.lastSequenceNumber,
+    } as unknown as StreamingEvent;
+
+    const responseState = this.router.responseService.current;
+    if (!this.router.responseService.isTerminal) {
+      violations.push({
+        rule: "RESPONSE_NOT_TERMINATED",
+        event: sentinel,
+        currentState: responseState,
+        message: `Stream ended without a terminal response event (last state: '${responseState}')`,
+      });
+    }
+
+    for (const [itemId, svc] of this.router.itemServices) {
+      if (!svc.isTerminal) {
+        violations.push({
+          rule: "ITEM_NOT_TERMINATED",
+          event: sentinel,
+          currentState: svc.current,
+          message: `Stream ended with item '${itemId}' in non-terminal state '${svc.current}'`,
+        });
+      }
+    }
+
+    for (const [key, svc] of this.router.contentPartServices) {
+      if (!svc.isTerminal) {
+        violations.push({
+          rule: "CONTENT_PART_NOT_TERMINATED",
+          event: sentinel,
+          currentState: svc.current,
+          message: `Stream ended with content part '${key}' in non-terminal state '${svc.current}'`,
+        });
+      }
+    }
+
+    this.allViolations.push(...violations);
+    return { valid: violations.length === 0, violations };
+  }
+
+  /** All violations accumulated across all send() and finalize() calls. */
+  get violations(): Violation[] {
+    return this.allViolations;
+  }
+}

--- a/state-machines/typescript/tsconfig.json
+++ b/state-machines/typescript/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "types": ["bun"],
+    "lib": ["ESNext"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Introduces a new `state-machines/typescript` package (`@openresponses/state-machine`) that validates streaming event ordering using finite state machines
- Adds a pluggable `BufferAdapter` interface + `InMemoryBufferAdapter` so callers connected to queue systems can reorder out-of-order events before they hit the validator
- Exports `createResponseStream` (async generator) and `createResponseTransformStream` (Web Streams) that pass events through unchanged when no buffer is provided, preserving all existing behavior
- Wires `ResponseStreamValidator` into the compliance-test suite via a new `streamingEventOrder` check

## New package: `state-machines/typescript`

| File | Purpose |
|------|---------|
| `src/types.ts` | Minimal discriminated union for all streaming event types |
| `src/machines.ts` | robot3 FSM definitions for response / item / content-part lifecycles |
| `src/router.ts` | Routes events to the correct FSM, returns violations |
| `src/validator.ts` | `ResponseStreamValidator` — stateful validator over a stream |
| `src/buffer.ts` | `BufferAdapter` interface + `InMemoryBufferAdapter` |
| `src/stream-processor.ts` | `createResponseStream` + `createResponseTransformStream` |
| `src/validator.test.ts` | 24 tests for the FSM validator |
| `src/stream-processor.test.ts` | 12 tests: pass-through, late gateways, transitive unlock, multi-item, unreachable gateways, custom adapter spy |
| `examples/in-memory-buffer.ts` | End-to-end example with out-of-order events |
| `examples/custom-adapter.ts` | Documented Redis adapter implementation |

## How the buffer works

```
input stream (any order)
  → createResponseStream({ buffer })
  → output stream (valid dependency order)
  → ResponseStreamValidator
```

Gateway events (`response.output_item.added`, `response.content_part.added`) open item/content-part slots and trigger a drain loop that re-emits now-valid buffered events. The drain loop repeats until no new events are unlocked, handling transitive dependencies (item gate → content gate → content deltas). At end-of-stream any remaining buffered events are emitted unconditionally so nothing is silently dropped.

## Test plan

- [x] `bun run tsc --noEmit` — no type errors
- [x] `bun test` inside `state-machines/typescript/` — all 36 tests pass
- [x] `bun run state-machines/typescript/examples/in-memory-buffer.ts` — events emitted in correct dependency order, no structural violations
- [x] Existing `validator.test.ts` (24 tests) unchanged and passing