### PR TITLE
fix: handle multiline and final SSE events

### DIFF
--- a/src/lib/sse-parser.test.ts
+++ b/src/lib/sse-parser.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { parseSSEStream } from "./sse-parser";
+
+const encoder = new TextEncoder();
+
+function streamResponse(...chunks: string[]): Response {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk));
+        }
+        controller.close();
+      },
+    }),
+  );
+}
+
+const textDeltaEvent = (delta: string) => ({
+  type: "response.output_text.delta",
+  sequence_number: 1,
+  item_id: "item_1",
+  output_index: 0,
+  content_index: 0,
+  delta,
+});
+
+describe("parseSSEStream", () => {
+  it("concatenates multi-line SSE data fields before parsing", async () => {
+    const response = streamResponse(
+      [
+        "event: response.output_text.delta",
+        'data: {"type":"response.output_text.delta",',
+        'data: "sequence_number":1,"item_id":"item_1",',
+        'data: "output_index":0,"content_index":0,"delta":"hello"}',
+        "",
+        "",
+      ].join("\n"),
+    );
+
+    const result = await parseSSEStream(response);
+
+    expect(result.errors).toEqual([]);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].data).toEqual(textDeltaEvent("hello"));
+  });
+
+  it("dispatches the final event when the stream closes without a blank line", async () => {
+    const response = streamResponse(
+      [
+        "event: response.output_text.delta",
+        `data: ${JSON.stringify(textDeltaEvent("tail"))}`,
+      ].join("\n"),
+    );
+
+    const result = await parseSSEStream(response);
+
+    expect(result.errors).toEqual([]);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].data).toEqual(textDeltaEvent("tail"));
+  });
+});

--- a/src/lib/sse-parser.ts
+++ b/src/lib/sse-parser.ts
@@ -140,6 +140,53 @@ export async function parseSSEStream(
 
   const decoder = new TextDecoder();
   let buffer = "";
+  let currentEvent = "";
+  let currentDataLines: string[] = [];
+
+  const getFieldValue = (value: string) => {
+    const fieldValue = value.endsWith("\r") ? value.slice(0, -1) : value;
+    return fieldValue.startsWith(" ") ? fieldValue.slice(1) : fieldValue;
+  };
+
+  const dispatchEvent = () => {
+    if (currentDataLines.length === 0) return;
+
+    const currentData = currentDataLines.join("\n");
+    if (currentData === "[DONE]") {
+      // Skip the [DONE] sentinel - it's not a real event
+    } else {
+      try {
+        const parsed = JSON.parse(currentData);
+        const parsedEvent = parseStreamingEventData(parsed, currentEvent);
+        events.push(parsedEvent);
+
+        if (!parsedEvent.validationResult.success) {
+          errors.push(
+            `Event validation failed for ${parsedEvent.event}: ${JSON.stringify(parsedEvent.validationResult.error.issues)}`,
+          );
+        }
+
+        finalResponse = getTerminalResponse(parsed) ?? finalResponse;
+      } catch {
+        errors.push(`Failed to parse event data: ${currentData}`);
+      }
+    }
+
+    currentEvent = "";
+    currentDataLines = [];
+  };
+
+  const processLine = (line: string) => {
+    if (line.endsWith("\r")) line = line.slice(0, -1);
+
+    if (line.startsWith("event:")) {
+      currentEvent = getFieldValue(line.slice(6));
+    } else if (line.startsWith("data:")) {
+      currentDataLines.push(getFieldValue(line.slice(5)));
+    } else if (line === "") {
+      dispatchEvent();
+    }
+  };
 
   try {
     while (true) {
@@ -150,39 +197,18 @@ export async function parseSSEStream(
       const lines = buffer.split("\n");
       buffer = lines.pop() || "";
 
-      let currentEvent = "";
-      let currentData = "";
-
       for (const line of lines) {
-        if (line.startsWith("event:")) {
-          currentEvent = line.slice(6).trim();
-        } else if (line.startsWith("data:")) {
-          currentData = line.slice(5).trim();
-        } else if (line === "" && currentData) {
-          if (currentData === "[DONE]") {
-            // Skip the [DONE] sentinel - it's not a real event
-          } else {
-            try {
-              const parsed = JSON.parse(currentData);
-              const parsedEvent = parseStreamingEventData(parsed, currentEvent);
-              events.push(parsedEvent);
-
-              if (!parsedEvent.validationResult.success) {
-                errors.push(
-                  `Event validation failed for ${parsedEvent.event}: ${JSON.stringify(parsedEvent.validationResult.error.issues)}`,
-                );
-              }
-
-              finalResponse = getTerminalResponse(parsed) ?? finalResponse;
-            } catch {
-              errors.push(`Failed to parse event data: ${currentData}`);
-            }
-          }
-          currentEvent = "";
-          currentData = "";
-        }
+        processLine(line);
       }
     }
+
+    buffer += decoder.decode();
+    if (buffer) {
+      for (const line of buffer.split("\n")) {
+        processLine(line);
+      }
+    }
+    dispatchEvent();
   } finally {
     reader.releaseLock();
   }


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- keep SSE parser state across chunks and concatenate repeated `data:` fields with newlines before JSON parsing
- flush the `TextDecoder` and dispatch any pending event when the stream closes without a trailing blank line
- add regression coverage for multi-line data events and final events without a blank line

## Tests
- `bun install --frozen-lockfile`
- `bun test src/lib/sse-parser.test.ts`
- `bun test`
- `bun run prettier --check .`
- `bunx tsc --noEmit`
- `git diff --check HEAD~1 HEAD`

Fixes #56
